### PR TITLE
Make start_date and end_date optional in get_report_results with smart defaults

### DIFF
--- a/src/kayzen-reporting/package.json
+++ b/src/kayzen-reporting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feedmob/kayzen-reporting",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "MCP server for Kayzen API",
   "main": "dist/index.js",
   "author": "FeedMob",


### PR DESCRIPTION

- Modified get_report_results to accept optional start_date and end_date parameters
- When dates are not provided, automatically uses report's original date range
- Added getReportDetails helper function to fetch report metadata
- Enhanced list_reports response with LLM guidance for date range usage
- Added date source tracking in response (user_specified vs report_original)
- Bumped version to 0.0.9

🤖 Generated with [Claude Code](https://claude.ai/code)