### PR TITLE
[codex] add metadata-driven MCP installer scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # FeedMob MCP Installer
 
-统一安装入口已经改成按 `serverKey` 选择目标 server，而不是为单个包写死一套脚本。
+The installer now uses a unified entry point that selects the target server by `serverKey`, instead of maintaining a separate hard-coded script for a single package.
 
 ## Usage
 
@@ -20,7 +20,7 @@ powershell -ExecutionPolicy Bypass -File scripts\install.ps1 sensor-tower-report
 
 ## Current Metadata Set
 
-当前已接入 24 个 MCP CLI server 的安装元数据，覆盖仓库里所有带 `bin` 的 MCP server 包：
+The installer metadata currently covers all 24 MCP CLI packages in this repository that expose a `bin` entry:
 
 - `applovin-reporting`
 - `appsamurai-reporting`
@@ -47,23 +47,23 @@ powershell -ExecutionPolicy Bypass -File scripts\install.ps1 sensor-tower-report
 - `user-activity-reporting`
 - `work-journals`
 
-元数据文件位于 `scripts/servers/*.json`。
+Metadata files live under `scripts/servers/*.json`.
 
 ## Design
 
-脚本结构：
+Structure:
 
 - `install.sh` / `install.ps1`
-  - 统一安装入口
-  - 校验本机环境
-  - 读取 `scripts/servers/<server>.json`
-  - 交互采集环境变量
-  - 备份并写入 Claude Desktop `mcpServers`
+  - Unified installer entry points
+  - Validate the local environment
+  - Read `scripts/servers/<server>.json`
+  - Collect environment variables interactively
+  - Back up and update Claude Desktop `mcpServers`
 - `servers/*.json`
-  - 定义 server 名称、npm 包名、命令参数、环境变量采集规则
+  - Define server names, npm package names, command args, and environment variable prompts
 
 ## Notes
 
-- macOS 安装器会显式注入 `PATH`，因为 Claude Desktop 通常不会继承 shell 的完整 PATH。
-- Windows 安装器默认不注入 `PATH`。
-- 第一版暂不支持 `--all`、版本 pin、远程拉取 metadata、`multiline` 交互输入。
+- The macOS installer explicitly injects `PATH` because Claude Desktop usually does not inherit the full shell `PATH`.
+- The Windows installer does not inject `PATH` by default.
+- The first version does not yet support `--all`, version pinning, remote metadata fetching, or `multiline` interactive input.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,316 +1,69 @@
-# Sensor Tower MCP Server Installation Script
+# FeedMob MCP Installer
 
-> **Status**: MVP v1.0 - Sensor Tower Reporting only. Multi-server support and other enhancements coming in future versions.
+统一安装入口已经改成按 `serverKey` 选择目标 server，而不是为单个包写死一套脚本。
 
-This script automates the installation of the FeedMob Sensor Tower MCP Server into Claude Desktop. Both macOS and Windows are supported.
+## Usage
 
-## Prerequisites
-
-| Requirement | macOS | Windows |
-|---|---|---|
-| **OS Version** | 10.15 or later | Windows 10 or later |
-| **Node.js** | >= 18 | >= 18 |
-| **npm** | Included with Node.js | Included with Node.js |
-| **jq (macOS) / PowerShell (Windows)** | Required | Built-in (5.1+) |
-| **Claude Desktop** | Required | Required |
-
-## Quick Start
-
-### macOS
-
-#### Option 1: Run Locally (Recommended)
-```bash
-bash scripts/install.sh
-```
-
-#### Option 2: Download and Run from GitHub
-```bash
-curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash
-```
-
-> **Security Note**: The curl method downloads the script from the GitHub repository. For enhanced security, you can:
->
-> - **Verify with Git**: Clone the repo and run locally (Option 1)
-> - **Pin a specific version**: Replace `main` with a release tag
->   ```bash
->   curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash
->   ```
-> - **Review before running**:
->   ```bash
->   curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | less
->   # Then copy and paste into terminal after review
->   ```
-
-### Windows
-
-#### Option 1: Run Locally (Recommended)
-
-Open PowerShell and run:
-
-```powershell
-powershell -ExecutionPolicy Bypass -File scripts\install.ps1
-```
-
-> **What is `-ExecutionPolicy Bypass`?** By default, Windows prevents unsigned PowerShell scripts from running. The `-ExecutionPolicy Bypass` flag allows this script to run just once without changing your system settings. Your execution policy remains unchanged after the script completes.
-
-#### Option 2: Download and Run from GitHub
-
-```powershell
-$scriptUrl = "https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.ps1"
-$scriptPath = "$env:TEMP\install.ps1"
-Invoke-WebRequest -Uri $scriptUrl -OutFile $scriptPath
-powershell -ExecutionPolicy Bypass -File $scriptPath
-```
-
-> **Security Note**: Similar to the macOS version, you can:
->
-> - **Verify with Git**: Clone the repo and run locally (Option 1)
-> - **Pin a specific version**: Replace `main` with a release tag
-> - **Review before running**:
->   ```powershell
->   $scriptUrl = "https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.ps1"
->   Invoke-WebRequest -Uri $scriptUrl | Select-Object -ExpandProperty Content | Less
->   # Then copy the URL and download after review
->   ```
-
-#### Alternative: One-Liner with Review
-
-If you want to review the script before running:
-
-```powershell
-# Step 1: Download and view
-$scriptUrl = "https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.ps1"
-Invoke-WebRequest -Uri $scriptUrl | Select-Object -ExpandProperty Content
-
-# Step 2: After reviewing, run it
-powershell -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri $scriptUrl -OutFile $env:TEMP\install.ps1; & $env:TEMP\install.ps1"
-```
-
-## What the Script Does
-
-Both the macOS (`install.sh`) and Windows (`install.ps1`) scripts follow the same 6-step process:
-
-1. **Checks your system** for OS, Node.js (>= 18), and npx
-2. **Verifies** Claude Desktop configuration file exists and is valid
-3. **Prompts you to enter**:
-   - `AUTH_TOKEN` (from Sensor Tower, hidden input for security)
-4. **Uses default values**:
-   - `SENSOR_TOWER_BASE_URL` = `https://api.sensortower.com`
-5. **Previews** the changes before applying them and asks for confirmation
-6. **Backs up** your existing configuration (with timestamp)
-7. **Updates** the Claude Desktop config file with Sensor Tower settings
-8. **Guides you** to restart Claude Desktop
-
-## What Gets Configured
-
-The script will add the following to your Claude Desktop configuration:
-
-### macOS (`~/Library/Application Support/Claude/claude_desktop_config.json`)
-
-```json
-{
-  "mcpServers": {
-    "sensor-tower-reporting": {
-      "command": "/opt/homebrew/bin/npx",
-      "args": ["-y", "@feedmob/sensor-tower-reporting"],
-      "env": {
-        "AUTH_TOKEN": "your_token_here",
-        "SENSOR_TOWER_BASE_URL": "https://api.sensortower.com",
-        "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-      }
-    }
-  }
-}
-```
-
-### Windows (`%APPDATA%\Claude\claude_desktop_config.json`)
-
-```json
-{
-  "mcpServers": {
-    "sensor-tower-reporting": {
-      "command": "npx",
-      "args": ["-y", "@feedmob/sensor-tower-reporting"],
-      "env": {
-        "AUTH_TOKEN": "your_token_here",
-        "SENSOR_TOWER_BASE_URL": "https://api.sensortower.com"
-      }
-    }
-  }
-}
-```
-
-> **Note**: On Windows, the `PATH` environment variable is not injected by the script since Windows processes inherit the full system PATH automatically. On macOS, it must be explicitly set because Claude Desktop doesn't inherit the shell's PATH.
-
-## Getting AUTH_TOKEN
-
-1. Log in to [Sensor Tower](https://www.sensortower.com/)
-2. Go to Settings → API Keys
-3. Generate or copy your API authentication token
-4. Paste it when the script prompts you
-
-### 🔒 Security Notes
-
-- **Input Handling**:
-  - macOS: Your API token is entered interactively (not stored in shell history thanks to `read -s`)
-  - Windows: Your API token is entered interactively with `Read-Host -AsSecureString` (not echoed to screen)
-- The token is written to `claude_desktop_config.json` which is restricted to user-only permissions
-- A backup of your config is created before any changes
-- **Never** share your AUTH_TOKEN or commit it to version control
-- To revoke your token, visit Sensor Tower's Settings → API Keys and delete it there
-
-## Troubleshooting
-
-### macOS
-
-#### "Command not found: node"
-
-Node.js is not installed. Install it via Homebrew:
+### macOS / Linux shell
 
 ```bash
-brew install node
-```
-
-#### "Node.js version too old"
-
-Upgrade to version 18 or later:
-
-```bash
-brew upgrade node
-```
-
-#### "npx not found"
-
-Reinstall Node.js:
-
-```bash
-brew reinstall node
-```
-
-#### "Config file has invalid JSON format"
-
-Your Claude Desktop config file is corrupted. Restore from backup:
-
-```bash
-# Find your most recent backup
-ls ~/Library/Application\ Support/Claude/claude_desktop_config.json.backup.*
-
-# Restore (replace with actual backup filename)
-cp ~/Library/Application\ Support/Claude/claude_desktop_config.json.backup.20240115_120530 \
-   ~/Library/Application\ Support/Claude/claude_desktop_config.json
+bash scripts/install.sh --list
+bash scripts/install.sh sensor-tower-reporting
 ```
 
 ### Windows
 
-#### "Node.js not detected"
-
-Node.js is not installed. Download and install from [nodejs.org](https://nodejs.org/)
-
-After installation, restart PowerShell or Command Prompt so it picks up the new PATH.
-
-#### "Node.js version too old"
-
-Update to version 18 or later from [nodejs.org](https://nodejs.org/)
-
-#### "npx not found"
-
-Reinstall Node.js from [nodejs.org](https://nodejs.org/)
-
-#### "Cannot be loaded because running scripts is disabled"
-
-Your PowerShell execution policy is too restrictive. The script uses `-ExecutionPolicy Bypass` to run just this once. If you're still getting this error:
-
 ```powershell
-# Check your current policy
-Get-ExecutionPolicy
-
-# Temporarily set it to RemoteSigned for the session
-Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-
-# Then run the script
-powershell -ExecutionPolicy Bypass -File scripts\install.ps1
+powershell -ExecutionPolicy Bypass -File scripts\install.ps1 --list
+powershell -ExecutionPolicy Bypass -File scripts\install.ps1 sensor-tower-reporting
 ```
 
-#### "Config file has invalid JSON format"
+## Current Metadata Set
 
-Your Claude Desktop config file is corrupted. Restore from backup:
+当前已接入 24 个 MCP CLI server 的安装元数据，覆盖仓库里所有带 `bin` 的 MCP server 包：
 
-```powershell
-# Find your most recent backup
-Get-ChildItem -Path "$env:APPDATA\Claude\claude_desktop_config.json.backup.*" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+- `applovin-reporting`
+- `appsamurai-reporting`
+- `civitai-records`
+- `feedmob-reporting`
+- `femini-reporting`
+- `github-issues`
+- `imagekit`
+- `impact-radius-reporting`
+- `inmobi-reporting`
+- `iplocate`
+- `ironsource-aura-reporting`
+- `ironsource-reporting`
+- `jampp-reporting`
+- `kayzen-reporting`
+- `liftoff-reporting`
+- `mintegral-reporting`
+- `rtb-house-reporting`
+- `samsung-reporting`
+- `sensor-tower-reporting`
+- `singular-reporting`
+- `smadex-reporting`
+- `tapjoy-reporting`
+- `user-activity-reporting`
+- `work-journals`
 
-# Restore (replace with actual backup filename)
-Copy-Item -Path "$env:APPDATA\Claude\claude_desktop_config.json.backup.20240115_120530" `
-          -Destination "$env:APPDATA\Claude\claude_desktop_config.json" -Force
-```
+元数据文件位于 `scripts/servers/*.json`。
 
-## After Installation
+## Design
 
-1. **Fully quit Claude Desktop** (macOS: ⌘Q, Windows: Alt+F4 or close from taskbar)
-2. **Reopen Claude Desktop**
-3. You should see Sensor Tower tools available in Claude Desktop
+脚本结构：
 
-## Manual Configuration
+- `install.sh` / `install.ps1`
+  - 统一安装入口
+  - 校验本机环境
+  - 读取 `scripts/servers/<server>.json`
+  - 交互采集环境变量
+  - 备份并写入 Claude Desktop `mcpServers`
+- `servers/*.json`
+  - 定义 server 名称、npm 包名、命令参数、环境变量采集规则
 
-### macOS
+## Notes
 
-If you prefer to configure manually, edit:
-
-```
-~/Library/Application Support/Claude/claude_desktop_config.json
-```
-
-And add this to the `mcpServers` section:
-
-```json
-"sensor-tower-reporting": {
-  "command": "/opt/homebrew/bin/npx",
-  "args": ["-y", "@feedmob/sensor-tower-reporting"],
-  "env": {
-    "AUTH_TOKEN": "your_token_here",
-    "SENSOR_TOWER_BASE_URL": "https://api.sensortower.com",
-    "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-  }
-}
-```
-
-### Windows
-
-If you prefer to configure manually, edit:
-
-```
-%APPDATA%\Claude\claude_desktop_config.json
-```
-
-Which typically expands to:
-
-```
-C:\Users\YourUsername\AppData\Roaming\Claude\claude_desktop_config.json
-```
-
-And add this to the `mcpServers` section:
-
-```json
-"sensor-tower-reporting": {
-  "command": "npx",
-  "args": ["-y", "@feedmob/sensor-tower-reporting"],
-  "env": {
-    "AUTH_TOKEN": "your_token_here",
-    "SENSOR_TOWER_BASE_URL": "https://api.sensortower.com"
-  }
-}
-```
-
-## Support
-
-For issues or questions:
-- Check the [Sensor Tower README](../src/sensor-tower-reporting/README.md)
-- Open an issue on GitHub
-- Contact the FeedMob team
-
-## Planned Enhancements (v2.0+)
-
-- Support for additional MCP Servers (feedmob-reporting, github-issues, work-journals, etc.)
-- Interactive server selection menu for multiple simultaneous installations
-- Recommended bundles (e.g., "Reporting Bundle", "Internal Tools Bundle")
-- One-line installation from web (curl | bash on macOS, irm | iex on Windows)
+- macOS 安装器会显式注入 `PATH`，因为 Claude Desktop 通常不会继承 shell 的完整 PATH。
+- Windows 安装器默认不注入 `PATH`。
+- 第一版暂不支持 `--all`、版本 pin、远程拉取 metadata、`multiline` 交互输入。

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,36 +1,15 @@
 #Requires -Version 5.1
-<#
-.SYNOPSIS
-    FeedMob MCP Server Installation Tool (Windows)
-
-.DESCRIPTION
-    Automates the installation of the FeedMob Sensor Tower MCP Server into Claude Desktop on Windows.
-
-.EXAMPLE
-    powershell -ExecutionPolicy Bypass -File scripts\install.ps1
-#>
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-# Configuration
 $ConfigFile = "$env:APPDATA\Claude\claude_desktop_config.json"
-$NPMPackage = "@feedmob/sensor-tower-reporting"
-$ServerKey = "sensor-tower-reporting"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ServersDir = Join-Path $ScriptDir "servers"
+$ServerKey = $args[0]
 
-# ============================================================================
-# Helper Functions
-# ============================================================================
-
-function Write-Banner {
-    Write-Host ""
-    Write-Host "╔════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-    Write-Host "║                                                            ║" -ForegroundColor Cyan
-    Write-Host "║     FeedMob MCP Server Installation Tool (Sensor Tower)    ║" -ForegroundColor Cyan
-    Write-Host "║                                                            ║" -ForegroundColor Cyan
-    Write-Host "╚════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
-    Write-Host ""
-}
+$script:Metadata = $null
+$script:NpxPath = $null
 
 function Write-Success {
     param([string]$Message)
@@ -47,11 +26,6 @@ function Write-Warning-Custom {
     Write-Host "⚠ $Message" -ForegroundColor Yellow
 }
 
-function Write-Info {
-    param([string]$Message)
-    Write-Host "ℹ $Message" -ForegroundColor Cyan
-}
-
 function Write-Section {
     param([string]$Title)
     Write-Host ""
@@ -61,46 +35,73 @@ function Write-Section {
     Write-Host ""
 }
 
-# ============================================================================
-# Environment Checks
-# ============================================================================
+function Show-Usage {
+    Write-Host "FeedMob MCP Installer"
+    Write-Host ""
+    Write-Host "Usage:"
+    Write-Host "  powershell -ExecutionPolicy Bypass -File scripts\install.ps1 <server-key>"
+    Write-Host "  powershell -ExecutionPolicy Bypass -File scripts\install.ps1 --list"
+}
+
+function Show-ServerList {
+    Write-Section "Available MCP Servers"
+    Get-ChildItem -Path $ServersDir -Filter *.json | Sort-Object Name | ForEach-Object {
+        $metadata = Get-Content -Path $_.FullName -Raw | ConvertFrom-Json
+        Write-Host "  - $($metadata.serverKey)"
+        Write-Host "    $($metadata.displayName) ($($metadata.packageName))"
+    }
+}
+
+function Initialize-Metadata {
+    if (-not $ServerKey) {
+        Show-Usage
+        exit 1
+    }
+
+    if ($ServerKey -eq "--list") {
+        Show-ServerList
+        exit 0
+    }
+
+    $metadataFile = Join-Path $ServersDir "$ServerKey.json"
+    if (-not (Test-Path $metadataFile)) {
+        Write-Error-Custom "Unknown server: $ServerKey"
+        Write-Host ""
+        Show-Usage
+        Write-Host ""
+        Show-ServerList
+        exit 1
+    }
+
+    $script:Metadata = Get-Content -Path $metadataFile -Raw | ConvertFrom-Json
+}
+
+function Write-Banner {
+    Write-Host ""
+    Write-Host "╔════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+    Write-Host ("║ {0,-58} ║" -f "FeedMob MCP Installer") -ForegroundColor Cyan
+    Write-Host ("║ {0,-58} ║" -f $Metadata.displayName) -ForegroundColor Cyan
+    Write-Host "╚════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+    Write-Host ""
+}
 
 function Test-System {
     Write-Section "Step 1: System Environment Check"
 
-    # Check Windows
-    if ($PSVersionTable.Platform -ne "Win32NT" -and $PSVersionTable.OS -notmatch "Windows") {
-        if ($PSVersionTable.PSVersion.Major -lt 5) {
-            Write-Error-Custom "PowerShell 5.1 or later required on non-Windows systems"
-            exit 1
-        }
-    }
-    Write-Success "Windows system check passed"
-
-    # Check Node.js
     try {
-        $nodeCmd = Get-Command node -ErrorAction Stop
         $nodeVersion = & node -v
     } catch {
         Write-Error-Custom "Node.js not detected. Please install it first."
-        Write-Host ""
-        Write-Host "Download from: https://nodejs.org/"
-        Write-Host ""
         exit 1
     }
 
     $nodeMajorVersion = [int]($nodeVersion -replace 'v(\d+)\..*', '$1')
     if ($nodeMajorVersion -lt 18) {
         Write-Error-Custom "Node.js version too old ($nodeVersion). Required: >= 18"
-        Write-Host ""
-        Write-Host "Please upgrade from: https://nodejs.org/"
-        Write-Host ""
         exit 1
     }
     Write-Success "Node.js version check passed ($nodeVersion)"
 
-    # Find npx path
-    $npxPath = $null
     $npxCandidates = @(
         "C:\Program Files\nodejs\npx.cmd",
         "C:\Program Files (x86)\nodejs\npx.cmd",
@@ -110,129 +111,152 @@ function Test-System {
 
     foreach ($candidate in $npxCandidates) {
         if (Test-Path $candidate) {
-            $npxPath = $candidate
+            $script:NpxPath = $candidate
             break
         }
     }
 
-    if (-not $npxPath) {
+    if (-not $script:NpxPath) {
         try {
-            $npxCmd = Get-Command npx -ErrorAction Stop
-            $npxPath = $npxCmd.Source
+            $script:NpxPath = (Get-Command npx -ErrorAction Stop).Source
         } catch {
             Write-Error-Custom "npx not found. Please ensure Node.js is properly installed."
             exit 1
         }
     }
 
-    Write-Success "npx path: $npxPath"
+    Write-Success "npx path: $script:NpxPath"
 }
 
 function Test-ClaudeDesktop {
     Write-Section "Step 2: Claude Desktop Configuration Check"
 
-    # Check if Claude Desktop config exists
     if (-not (Test-Path $ConfigFile)) {
         Write-Warning-Custom "Claude Desktop config file not found. Creating new file."
-
         $configDir = Split-Path $ConfigFile
         if (-not (Test-Path $configDir)) {
             New-Item -ItemType Directory -Path $configDir -Force | Out-Null
         }
-
-        $defaultConfig = @{
-            mcpServers = @{}
-        }
-        $defaultConfig | ConvertTo-Json -Depth 10 | Set-Content -Path $ConfigFile -Encoding UTF8
+        @{ mcpServers = @{} } | ConvertTo-Json -Depth 10 | Set-Content -Path $ConfigFile -Encoding UTF8
         Write-Success "Config file created: $ConfigFile"
     } else {
         Write-Success "Config file found: $ConfigFile"
     }
 
-    # Validate JSON format
     try {
-        $configContent = Get-Content -Path $ConfigFile -Raw
-        $null = $configContent | ConvertFrom-Json -ErrorAction Stop
+        $null = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json -ErrorAction Stop
     } catch {
         Write-Error-Custom "Config file has invalid JSON format"
-        Write-Host ""
-        Write-Host "Error: $_"
+        Write-Host $_
         exit 1
     }
 
     Write-Success "Config file JSON format is valid"
 }
 
-# ============================================================================
-# Collect Environment Variables
-# ============================================================================
+function Mask-Value {
+    param([string]$Value)
 
-function Get-EnvVars {
-    Write-Section "Step 3: Configure Sensor Tower"
+    if ([string]::IsNullOrEmpty($Value)) {
+        return "(empty)"
+    }
 
-    # AUTH_TOKEN (required, hidden)
+    if ($Value.Length -le 3) {
+        return $Value
+    }
+
+    $maskCount = $Value.Length - 3
+    return ('•' * $maskCount) + $Value.Substring($Value.Length - 3, 3)
+}
+
+function Read-EnvValue {
+    param([object]$Item)
+
+    Write-Section "Configure $($Item.name)"
+    if ($Item.description) {
+        Write-Host $Item.description
+        Write-Host ""
+    }
+
+    if ($Item.multiline) {
+        Write-Error-Custom "multiline env is not supported yet in Windows installer: $($Item.name)"
+        exit 1
+    }
+
+    $required = if ($Item.required) { "required" } else { "optional" }
+    if ($Item.PSObject.Properties.Name -contains "default" -and $Item.default) {
+        $required = "$required, default: $($Item.default)"
+    }
+
     while ($true) {
-        $secureToken = Read-Host "Enter AUTH_TOKEN (required, input will be hidden)" -AsSecureString
+        if ($Item.secret) {
+            $secureValue = Read-Host "Enter $($Item.name) ($required)" -AsSecureString
+            $ptr = [System.Runtime.InteropServices.Marshal]::SecureStringToCoTaskMemUnicode($secureValue)
+            try {
+                $value = [System.Runtime.InteropServices.Marshal]::PtrToStringUni($ptr)
+            } finally {
+                [System.Runtime.InteropServices.Marshal]::ZeroFreeCoTaskMemUnicode($ptr)
+            }
+        } else {
+            $value = Read-Host "Enter $($Item.name) ($required)"
+        }
 
-        if ($secureToken.Length -eq 0) {
-            Write-Error-Custom "AUTH_TOKEN cannot be empty. Please try again."
-            Write-Host ""
+        if ([string]::IsNullOrEmpty($value) -and ($Item.PSObject.Properties.Name -contains "default") -and $Item.default) {
+            $value = [string]$Item.default
+        }
+
+        if ([string]::IsNullOrEmpty($value) -and $Item.required) {
+            Write-Error-Custom "$($Item.name) cannot be empty. Please try again."
             continue
         }
 
-        # Convert SecureString to plaintext
-        $ptr = [System.Runtime.InteropServices.Marshal]::SecureStringToCoTaskMemUnicode($secureToken)
-        $script:AuthToken = [System.Runtime.InteropServices.Marshal]::PtrToStringUni($ptr)
-        [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr)
-
-        # Display masked token for confirmation (show last 3 characters)
-        $tokenLength = $AuthToken.Length
-        if ($tokenLength -le 3) {
-            $maskedToken = $AuthToken
-        } else {
-            $maskCount = $tokenLength - 3
-            $maskedPrefix = '•' * $maskCount
-            $last3 = $AuthToken.Substring($tokenLength - 3, 3)
-            $maskedToken = "$maskedPrefix$last3"
+        $display = if ($Item.secret) { Mask-Value -Value $value } elseif ([string]::IsNullOrEmpty($value)) { "(not set)" } else { $value }
+        return @{
+            Name = [string]$Item.name
+            Value = [string]$value
+            Display = [string]$display
         }
-
-        Write-Host "✓ AUTH_TOKEN entered: $maskedToken" -ForegroundColor Green
-        $script:MaskedToken = $maskedToken
-        break
     }
-
-    # SENSOR_TOWER_BASE_URL (use default)
-    $script:SensorTowerBaseUrl = "https://api.sensortower.com"
-    Write-Success "SENSOR_TOWER_BASE_URL: $SensorTowerBaseUrl (default)"
 }
 
-# ============================================================================
-# Preview & Confirmation
-# ============================================================================
+function Get-EnvValues {
+    $values = @()
+
+    if (-not $Metadata.env) {
+        Write-Section "Step 3: Configure Environment"
+        Write-Success "No environment variables required"
+        return $values
+    }
+
+    foreach ($item in $Metadata.env) {
+        $values += Read-EnvValue -Item $item
+    }
+
+    return $values
+}
 
 function Show-Preview {
+    param([array]$EnvValues)
+
     Write-Section "Step 4: Installation Preview"
 
-    # Check if server already exists
-    $configContent = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
-    if ($configContent.mcpServers.PSObject.Properties.Name -contains $ServerKey) {
-        Write-Warning-Custom "Sensor Tower is already configured. It will be overwritten."
+    $config = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+    if ($config.mcpServers -and $config.mcpServers.PSObject.Properties.Name -contains $Metadata.serverKey) {
+        Write-Warning-Custom "$($Metadata.displayName) is already configured. It will be overwritten."
         Write-Host ""
     }
 
     Write-Host "The following will be added/updated to Claude Desktop config:"
     Write-Host ""
-    Write-Host "Server name:" -ForegroundColor Cyan -NoNewline
-    Write-Host " $ServerKey"
-    Write-Host "npm package:" -ForegroundColor Cyan -NoNewline
-    Write-Host " $NPMPackage"
-    Write-Host "Command:" -ForegroundColor Cyan -NoNewline
-    Write-Host " npx"
-    Write-Host "Args:" -ForegroundColor Cyan -NoNewline
-    Write-Host " ['-y', '$NPMPackage']"
-    Write-Host "Environment variables:" -ForegroundColor Cyan
-    Write-Host "  - AUTH_TOKEN: $MaskedToken"
-    Write-Host "  - SENSOR_TOWER_BASE_URL: $SensorTowerBaseUrl"
+    Write-Host "Server name: $($Metadata.serverKey)"
+    Write-Host "Display name: $($Metadata.displayName)"
+    Write-Host "npm package: $($Metadata.packageName)"
+    Write-Host "Command: $script:NpxPath"
+    Write-Host "Args: $($Metadata.command.args -join ' ')"
+    Write-Host "Environment variables:"
+    foreach ($entry in $EnvValues) {
+        Write-Host "  - $($entry.Name): $($entry.Display)"
+    }
     Write-Host ""
 
     $confirm = Read-Host "Confirm installation? (y/n)"
@@ -242,95 +266,79 @@ function Show-Preview {
     }
 }
 
-# ============================================================================
-# Backup & Install
-# ============================================================================
-
 function Backup-Config {
     Write-Section "Step 5: Backing up existing configuration"
-
-    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
-    $backupFile = "$ConfigFile.backup.$timestamp"
+    $backupFile = "$ConfigFile.backup.$(Get-Date -Format 'yyyyMMdd_HHmmss')"
     Copy-Item -Path $ConfigFile -Destination $backupFile -Force
     Write-Success "Config file backed up to: $backupFile"
-    Write-Host "To restore: copy `"$backupFile`" `"$ConfigFile`""
 }
 
 function Update-Config {
+    param([array]$EnvValues)
+
     Write-Section "Step 6: Updating configuration file"
+    $config = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
 
-    # Read current config
-    $configContent = Get-Content -Path $ConfigFile -Raw | ConvertFrom-Json
+    if (-not $config.mcpServers) {
+        $config | Add-Member -NotePropertyName mcpServers -NotePropertyValue ([pscustomobject]@{})
+    }
 
-    # Create server configuration
-    $serverConfig = @{
-        command = "npx"
-        args = @("-y", $NPMPackage)
-        env = @{
-            AUTH_TOKEN = $AuthToken
-            SENSOR_TOWER_BASE_URL = $SensorTowerBaseUrl
+    $envMap = [ordered]@{}
+    foreach ($entry in $EnvValues) {
+        if (-not [string]::IsNullOrEmpty($entry.Value)) {
+            $envMap[$entry.Name] = $entry.Value
         }
     }
 
-    # Add or update server in config
-    if ($null -eq $configContent.mcpServers) {
-        $configContent | Add-Member -NotePropertyName mcpServers -NotePropertyValue @{}
+    $serverConfig = [ordered]@{
+        command = $script:NpxPath
+        args = @($Metadata.command.args)
+        env = $envMap
     }
 
-    $configContent.mcpServers | Add-Member -NotePropertyName $ServerKey -NotePropertyValue $serverConfig -Force
+    $config.mcpServers | Add-Member -NotePropertyName $Metadata.serverKey -NotePropertyValue ([pscustomobject]$serverConfig) -Force
 
-    # Write to temporary file first
-    $tmpFile = "$ConfigFile.tmp.$([System.Guid]::NewGuid().ToString())"
-
+    $tmpFile = "$ConfigFile.tmp.$([guid]::NewGuid().ToString())"
     try {
-        $configJson = $configContent | ConvertTo-Json -Depth 10
-        $configJson | Set-Content -Path $tmpFile -Encoding UTF8
-
-        # Validate generated JSON
+        $config | ConvertTo-Json -Depth 10 | Set-Content -Path $tmpFile -Encoding UTF8
         $null = Get-Content -Path $tmpFile -Raw | ConvertFrom-Json
-
-        # Replace original with new config (atomic)
         Move-Item -Path $tmpFile -Destination $ConfigFile -Force
-
         Write-Success "Config file updated successfully"
     } catch {
-        Write-Error-Custom "Config update failed"
-        Write-Host ""
-        Write-Host "Error: $_"
         if (Test-Path $tmpFile) {
             Remove-Item -Path $tmpFile -Force
         }
+        Write-Error-Custom "Config update failed"
+        Write-Host $_
         exit 1
     }
 }
 
-# ============================================================================
-# Main Execution
-# ============================================================================
-
-function Main {
-    Write-Banner
-
-    Test-System
-    Test-ClaudeDesktop
-    Get-EnvVars
-    Show-Preview
-    Backup-Config
-    Update-Config
-
+function Write-Completion {
     Write-Section "Installation Complete!"
-    Write-Host "Sensor Tower MCP Server has been successfully installed" -ForegroundColor Green
+    Write-Host "$($Metadata.displayName) has been successfully installed" -ForegroundColor Green
     Write-Host ""
     Write-Host "Next steps:"
-    Write-Host "  " -NoNewline
-    Write-Host "1. Fully quit Claude Desktop (make sure it's completely closed)" -ForegroundColor Yellow
-    Write-Host "  " -NoNewline
-    Write-Host "2. Reopen Claude Desktop" -ForegroundColor Yellow
-    Write-Host ""
-    Write-Host "To verify the installation:"
-    Write-Host "  Check the tools list in Claude Desktop - you should see Sensor Tower tools"
-    Write-Host ""
-    Write-Success "Enjoy using Sensor Tower with Claude!"
+    if ($Metadata.postInstallMessage) {
+        foreach ($message in $Metadata.postInstallMessage) {
+            Write-Host "  - $message" -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "  - Fully quit Claude Desktop" -ForegroundColor Yellow
+        Write-Host "  - Reopen Claude Desktop" -ForegroundColor Yellow
+    }
+}
+
+function Main {
+    Initialize-Metadata
+    Write-Banner
+    Test-System
+    Test-ClaudeDesktop
+    $envValues = Get-EnvValues
+    Show-Preview -EnvValues $envValues
+    Backup-Config
+    Update-Config -EnvValues $envValues
+    Write-Completion
 }
 
 Main

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,33 +1,29 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-# Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# Configuration
 CONFIG_FILE="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
-NPM_PACKAGE="@feedmob/sensor-tower-reporting"
-SERVER_KEY="sensor-tower-reporting"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVERS_DIR="$SCRIPT_DIR/servers"
+MACOS_PATH_VALUE="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
-# ============================================================================
-# Helper Functions
-# ============================================================================
-
-print_banner() {
-  echo -e "${BLUE}"
-  echo "╔════════════════════════════════════════════════════════════╗"
-  echo "║                                                            ║"
-  echo "║     FeedMob MCP Server Installation Tool (Sensor Tower)    ║"
-  echo "║                                                            ║"
-  echo "╚════════════════════════════════════════════════════════════╝"
-  echo -e "${NC}"
-  echo ""
-}
+SERVER_KEY="${1:-}"
+METADATA_FILE=""
+DISPLAY_NAME=""
+PACKAGE_NAME=""
+COMMAND_TYPE=""
+INJECT_PATH="true"
+POST_INSTALL_MESSAGES=()
+ENV_KEYS=()
+ENV_DISPLAY_VALUES=()
+NPX_PATH=""
+BACKUP_FILE=""
 
 print_success() {
   echo -e "${GREEN}✓ $1${NC}"
@@ -41,10 +37,6 @@ print_warning() {
   echo -e "${YELLOW}⚠ $1${NC}"
 }
 
-print_info() {
-  echo -e "${BLUE}ℹ $1${NC}"
-}
-
 print_section() {
   echo ""
   echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
@@ -53,62 +45,120 @@ print_section() {
   echo ""
 }
 
-# ============================================================================
-# Environment Checks
-# ============================================================================
+usage() {
+  cat <<EOF
+FeedMob MCP Installer
+
+Usage:
+  bash scripts/install.sh <server-key>
+  bash scripts/install.sh --list
+
+Examples:
+  bash scripts/install.sh sensor-tower-reporting
+  bash scripts/install.sh applovin-reporting
+EOF
+}
+
+list_servers() {
+  print_section "Available MCP Servers"
+  if ! find "$SERVERS_DIR" -maxdepth 1 -name '*.json' | grep -q .; then
+    print_warning "No server metadata found in $SERVERS_DIR"
+    return
+  fi
+
+  while IFS= read -r file; do
+    local key name pkg
+    key=$(jq -r '.serverKey' "$file")
+    name=$(jq -r '.displayName' "$file")
+    pkg=$(jq -r '.packageName' "$file")
+    echo "  - $key"
+    echo "    $name ($pkg)"
+  done < <(find "$SERVERS_DIR" -maxdepth 1 -name '*.json' | sort)
+}
+
+validate_args() {
+  if [[ -z "$SERVER_KEY" ]]; then
+    usage
+    exit 1
+  fi
+
+  if [[ "$SERVER_KEY" == "--list" ]]; then
+    list_servers
+    exit 0
+  fi
+
+  METADATA_FILE="$SERVERS_DIR/$SERVER_KEY.json"
+  if [[ ! -f "$METADATA_FILE" ]]; then
+    print_error "Unknown server: $SERVER_KEY"
+    echo ""
+    usage
+    echo ""
+    list_servers
+    exit 1
+  fi
+}
+
+load_metadata() {
+  DISPLAY_NAME=$(jq -r '.displayName' "$METADATA_FILE")
+  PACKAGE_NAME=$(jq -r '.packageName' "$METADATA_FILE")
+  COMMAND_TYPE=$(jq -r '.command.type' "$METADATA_FILE")
+  INJECT_PATH=$(jq -r '.macos.injectPath // true' "$METADATA_FILE")
+
+  if [[ "$COMMAND_TYPE" != "npx" ]]; then
+    print_error "Unsupported command.type in $METADATA_FILE: $COMMAND_TYPE"
+    exit 1
+  fi
+
+  mapfile -t POST_INSTALL_MESSAGES < <(jq -r '.postInstallMessage[]?' "$METADATA_FILE")
+}
+
+print_banner() {
+  echo -e "${BLUE}"
+  echo "╔════════════════════════════════════════════════════════════╗"
+  printf "║ %-58s ║\n" "FeedMob MCP Installer"
+  printf "║ %-58s ║\n" "$DISPLAY_NAME"
+  echo "╚════════════════════════════════════════════════════════════╝"
+  echo -e "${NC}"
+}
 
 check_system() {
   print_section "Step 1: System Environment Check"
 
-  # Check macOS
   if [[ "$OSTYPE" != "darwin"* ]]; then
     print_error "This script only supports macOS. Your system is: $OSTYPE"
     exit 1
   fi
   print_success "macOS system check passed"
 
-  # Check Node.js
-  if ! command -v node &> /dev/null; then
+  if ! command -v node >/dev/null 2>&1; then
     print_error "Node.js not detected. Please install it first."
-    echo ""
-    echo "Recommended installation via Homebrew:"
-    echo -e "  ${YELLOW}brew install node${NC}"
-    echo ""
+    echo "  brew install node"
     exit 1
   fi
 
-  NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
-  if [[ $NODE_VERSION -lt 18 ]]; then
-    print_error "Node.js version too old ($NODE_VERSION). Required: >= 18"
-    echo ""
-    echo "Please upgrade Node.js:"
-    echo -e "  ${YELLOW}brew upgrade node${NC}"
-    echo ""
+  local node_major
+  node_major=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
+  if [[ "$node_major" -lt 18 ]]; then
+    print_error "Node.js version too old ($(node -v)). Required: >= 18"
     exit 1
   fi
-  print_success "Node.js version check passed (v$(node -v))"
+  print_success "Node.js version check passed ($(node -v))"
 
-  # Check jq (required for JSON manipulation)
-  if ! command -v jq &> /dev/null; then
+  if ! command -v jq >/dev/null 2>&1; then
     print_error "jq not detected. Please install it first."
-    echo ""
-    echo "Recommended installation via Homebrew:"
-    echo -e "  ${YELLOW}brew install jq${NC}"
-    echo ""
+    echo "  brew install jq"
     exit 1
   fi
   print_success "jq installation check passed"
 
-  # Find npx path
-  NPX_PATH=""
-  for candidate in /opt/homebrew/bin/npx /usr/local/bin/npx $(which npx 2>/dev/null); do
-    if [ -x "$candidate" ]; then
+  for candidate in /opt/homebrew/bin/npx /usr/local/bin/npx "$(which npx 2>/dev/null || true)"; do
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
       NPX_PATH="$candidate"
       break
     fi
   done
 
-  if [ -z "$NPX_PATH" ]; then
+  if [[ -z "$NPX_PATH" ]]; then
     print_error "npx not found. Please ensure Node.js is properly installed."
     exit 1
   fi
@@ -118,8 +168,7 @@ check_system() {
 check_claude_desktop() {
   print_section "Step 2: Claude Desktop Configuration Check"
 
-  # Check if Claude Desktop config exists
-  if [ ! -f "$CONFIG_FILE" ]; then
+  if [[ ! -f "$CONFIG_FILE" ]]; then
     print_warning "Claude Desktop config file not found. Creating new file."
     mkdir -p "$(dirname "$CONFIG_FILE")"
     echo '{"mcpServers": {}}' > "$CONFIG_FILE"
@@ -128,176 +177,242 @@ check_claude_desktop() {
     print_success "Config file found: $CONFIG_FILE"
   fi
 
-  # Validate JSON format
   if ! jq empty "$CONFIG_FILE" 2>/dev/null; then
     print_error "Config file has invalid JSON format"
-    echo ""
-    echo "Diagnostic info:"
     jq empty "$CONFIG_FILE" 2>&1 | sed 's/^/  /'
     exit 1
   fi
   print_success "Config file JSON format is valid"
 }
 
-# ============================================================================
-# Collect Environment Variables
-# ============================================================================
+mask_value() {
+  local value="$1"
+  if [[ -z "$value" ]]; then
+    echo "(empty)"
+    return
+  fi
 
-collect_env_vars() {
-  print_section "Step 3: Configure Sensor Tower"
+  local length=${#value}
+  if [[ "$length" -le 3 ]]; then
+    echo "$value"
+    return
+  fi
 
-  # AUTH_TOKEN (required, hidden)
-  while true; do
-    echo -n -e "${YELLOW}Enter AUTH_TOKEN (required, input will be hidden):${NC} "
-    read -s AUTH_TOKEN < /dev/tty
+  local mask_count=$((length - 3))
+  local masked_prefix
+  masked_prefix=$(printf '•%.0s' $(seq 1 "$mask_count"))
+  echo "${masked_prefix}${value: -3}"
+}
+
+prompt_env_value() {
+  local index="$1"
+  local name required secret multiline default_value description prompt_suffix value display_value
+
+  name=$(jq -r ".env[$index].name" "$METADATA_FILE")
+  required=$(jq -r ".env[$index].required // false" "$METADATA_FILE")
+  secret=$(jq -r ".env[$index].secret // false" "$METADATA_FILE")
+  multiline=$(jq -r ".env[$index].multiline // false" "$METADATA_FILE")
+  default_value=$(jq -r ".env[$index].default // empty" "$METADATA_FILE")
+  description=$(jq -r ".env[$index].description // empty" "$METADATA_FILE")
+
+  print_section "Configure $name"
+  if [[ -n "$description" ]]; then
+    echo "$description"
     echo ""
+  fi
 
-    if [ -z "$AUTH_TOKEN" ]; then
-      print_error "AUTH_TOKEN cannot be empty. Please try again."
+  if [[ "$multiline" == "true" ]]; then
+    print_error "multiline env is not supported yet in macOS installer: $name"
+    exit 1
+  fi
+
+  prompt_suffix=""
+  if [[ "$required" == "true" ]]; then
+    prompt_suffix="required"
+  else
+    prompt_suffix="optional"
+  fi
+  if [[ -n "$default_value" ]]; then
+    prompt_suffix="$prompt_suffix, default: $default_value"
+  fi
+
+  while true; do
+    if [[ "$secret" == "true" ]]; then
+      echo -n -e "${YELLOW}Enter $name ($prompt_suffix):${NC} "
+      read -r -s value < /dev/tty
+      echo ""
+    else
+      echo -n -e "${YELLOW}Enter $name ($prompt_suffix):${NC} "
+      read -r value < /dev/tty
+    fi
+
+    if [[ -z "$value" && -n "$default_value" ]]; then
+      value="$default_value"
+    fi
+
+    if [[ -z "$value" && "$required" == "true" ]]; then
+      print_error "$name cannot be empty. Please try again."
       echo ""
       continue
     fi
 
-    # Display masked token for confirmation (show last 3 characters)
-    TOKEN_LENGTH=${#AUTH_TOKEN}
-    if [ $TOKEN_LENGTH -le 3 ]; then
-      MASKED_TOKEN="$AUTH_TOKEN"
-    else
-      MASK_COUNT=$((TOKEN_LENGTH - 3))
-      MASKED_PREFIX=$(printf '•%.0s' $(seq 1 $MASK_COUNT))
-      LAST_3="${AUTH_TOKEN: -3}"
-      MASKED_TOKEN="$MASKED_PREFIX$LAST_3"
+    display_value="$value"
+    if [[ "$secret" == "true" ]]; then
+      display_value=$(mask_value "$value")
+    elif [[ -z "$display_value" ]]; then
+      display_value="(not set)"
     fi
 
-    echo -e "${GREEN}✓ AUTH_TOKEN entered: $MASKED_TOKEN${NC}"
+    export "ENV_VALUE_$name=$value"
+    ENV_KEYS+=("$name")
+    ENV_DISPLAY_VALUES+=("$display_value")
+    print_success "$name: $display_value"
     break
   done
-
-  # SENSOR_TOWER_BASE_URL (use default, no prompt)
-  SENSOR_TOWER_BASE_URL="https://api.sensortower.com"
-  print_success "SENSOR_TOWER_BASE_URL: $SENSOR_TOWER_BASE_URL (default)"
 }
 
-# ============================================================================
-# Preview & Confirmation
-# ============================================================================
+collect_env_vars() {
+  local count index
+  count=$(jq '.env | length' "$METADATA_FILE")
+  if [[ "$count" -eq 0 ]]; then
+    print_section "Step 3: Configure Environment"
+    print_success "No environment variables required"
+    return
+  fi
+
+  for ((index=0; index<count; index++)); do
+    prompt_env_value "$index"
+  done
+}
 
 show_preview() {
   print_section "Step 4: Installation Preview"
 
-  # Check if server already exists
   if jq -e ".mcpServers[\"$SERVER_KEY\"]" "$CONFIG_FILE" >/dev/null 2>&1; then
-    print_warning "Sensor Tower is already configured. It will be overwritten."
+    print_warning "$DISPLAY_NAME is already configured. It will be overwritten."
     echo ""
   fi
 
   echo "The following will be added/updated to Claude Desktop config:"
   echo ""
   echo -e "${BLUE}Server name:${NC} $SERVER_KEY"
-  echo -e "${BLUE}npm package:${NC} $NPM_PACKAGE"
-  echo -e "${BLUE}Command:${NC} npx"
-  echo -e "${BLUE}Args:${NC} ['-y', '$NPM_PACKAGE']"
+  echo -e "${BLUE}Display name:${NC} $DISPLAY_NAME"
+  echo -e "${BLUE}npm package:${NC} $PACKAGE_NAME"
+  echo -e "${BLUE}Command:${NC} $NPX_PATH"
+  echo -e "${BLUE}Args:${NC} ['-y', '$PACKAGE_NAME']"
   echo -e "${BLUE}Environment variables:${NC}"
-  echo "  - AUTH_TOKEN: $MASKED_TOKEN"
-  echo "  - SENSOR_TOWER_BASE_URL: $SENSOR_TOWER_BASE_URL"
-  echo "  - PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+  local idx
+  for idx in "${!ENV_KEYS[@]}"; do
+    echo "  - ${ENV_KEYS[$idx]}: ${ENV_DISPLAY_VALUES[$idx]}"
+  done
+  if [[ "$INJECT_PATH" == "true" ]]; then
+    echo "  - PATH: $MACOS_PATH_VALUE"
+  fi
   echo ""
 
   echo -n "Confirm installation? (y/n): "
-  read -r CONFIRM < /dev/tty
-  if [[ ! $CONFIRM =~ ^[Yy]$ ]]; then
+  local confirm
+  read -r confirm < /dev/tty
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
     print_error "Installation cancelled by user"
     exit 0
   fi
 }
 
-# ============================================================================
-# Backup & Install
-# ============================================================================
-
 backup_config() {
   print_section "Step 5: Backing up existing configuration"
-
   BACKUP_FILE="$CONFIG_FILE.backup.$(date +%Y%m%d_%H%M%S)"
   cp "$CONFIG_FILE" "$BACKUP_FILE"
   print_success "Config file backed up to: $BACKUP_FILE"
-  echo "To restore: cp $BACKUP_FILE $CONFIG_FILE"
+}
+
+build_env_json() {
+  local env_json idx key value value_var
+  env_json='{}'
+
+  for idx in "${!ENV_KEYS[@]}"; do
+    key="${ENV_KEYS[$idx]}"
+    value_var="ENV_VALUE_$key"
+    value="${!value_var-}"
+    if [[ -z "$value" ]]; then
+      continue
+    fi
+    env_json=$(jq -c --arg key "$key" --arg value "$value" '. + {($key): $value}' <<<"$env_json")
+  done
+
+  if [[ "$INJECT_PATH" == "true" ]]; then
+    env_json=$(jq -c --arg value "$MACOS_PATH_VALUE" '. + {"PATH": $value}' <<<"$env_json")
+  fi
+
+  echo "$env_json"
 }
 
 update_config() {
   print_section "Step 6: Updating configuration file"
 
-  TMP_FILE=$(mktemp)
-  trap "rm -f '$TMP_FILE' '${TMP_FILE}.new'" EXIT
+  local tmp_file new_file env_json args_json jq_output
+  tmp_file=$(mktemp)
+  new_file="${tmp_file}.new"
+  trap "rm -f '$tmp_file' '$new_file'" EXIT
+  cp "$CONFIG_FILE" "$tmp_file"
 
-  cp "$CONFIG_FILE" "$TMP_FILE"
+  env_json=$(build_env_json)
+  args_json=$(jq -c '.command.args' "$METADATA_FILE")
 
-  # Use jq to safely merge JSON configs
-  # jq --arg automatically escapes all special characters
-  local jq_output
   jq_output=$(jq \
     --arg key "$SERVER_KEY" \
     --arg cmd "$NPX_PATH" \
-    --arg pkg "$NPM_PACKAGE" \
-    --arg token "$AUTH_TOKEN" \
-    --arg url "$SENSOR_TOWER_BASE_URL" \
+    --argjson args "$args_json" \
+    --argjson env "$env_json" \
     '.mcpServers[$key] = {
       "command": $cmd,
-      "args": ["-y", $pkg],
-      "env": {
-        "AUTH_TOKEN": $token,
-        "SENSOR_TOWER_BASE_URL": $url,
-        "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-      }
-    }' "$TMP_FILE" 2>&1) || {
-    print_error "Config generation failed"
-    echo ""
-    echo "Diagnostic info:"
-    echo "$jq_output" | sed 's/^/  /'
-    exit 1
-  }
+      "args": $args,
+      "env": $env
+    }' "$tmp_file" 2>&1) || {
+      print_error "Config generation failed"
+      echo "$jq_output" | sed 's/^/  /'
+      exit 1
+    }
 
-  echo "$jq_output" > "${TMP_FILE}.new"
-
-  # Validate generated JSON format
-  if ! jq empty "${TMP_FILE}.new" 2>/dev/null; then
+  echo "$jq_output" > "$new_file"
+  if ! jq empty "$new_file" 2>/dev/null; then
     print_error "Generated config file has invalid JSON format"
-    echo ""
-    echo "Diagnostic info:"
-    jq empty "${TMP_FILE}.new" 2>&1 | sed 's/^/  /'
+    jq empty "$new_file" 2>&1 | sed 's/^/  /'
     exit 1
   fi
 
-  # Replace original config with validated new config
-  mv "${TMP_FILE}.new" "$CONFIG_FILE"
+  mv "$new_file" "$CONFIG_FILE"
   print_success "Config file updated successfully"
 }
 
-# ============================================================================
-# Main Execution
-# ============================================================================
+print_completion() {
+  print_section "Installation Complete!"
+  echo -e "${GREEN}$DISPLAY_NAME has been successfully installed${NC}"
+  echo ""
+  echo "Next steps:"
+  local message
+  if [[ "${#POST_INSTALL_MESSAGES[@]}" -gt 0 ]]; then
+    for message in "${POST_INSTALL_MESSAGES[@]}"; do
+      echo -e "  ${YELLOW}- $message${NC}"
+    done
+  else
+    echo -e "  ${YELLOW}- Fully quit Claude Desktop${NC}"
+    echo -e "  ${YELLOW}- Reopen Claude Desktop${NC}"
+  fi
+}
 
 main() {
+  validate_args
+  load_metadata
   print_banner
-
   check_system
   check_claude_desktop
   collect_env_vars
   show_preview
   backup_config
   update_config
-
-  print_section "Installation Complete!"
-  echo -e "${GREEN}Sensor Tower MCP Server has been successfully installed${NC}"
-  echo ""
-  echo "Next steps:"
-  echo -e "  ${YELLOW}1. Fully quit Claude Desktop (make sure it's completely closed)${NC}"
-  echo -e "  ${YELLOW}2. Reopen Claude Desktop${NC}"
-  echo ""
-  echo "To verify the installation:"
-  echo "  Check the tools list in Claude Desktop - you should see Sensor Tower tools"
-  echo ""
-  print_success "Enjoy using Sensor Tower with Claude!"
+  print_completion
 }
 
 main

--- a/scripts/servers/applovin-reporting.json
+++ b/scripts/servers/applovin-reporting.json
@@ -1,0 +1,25 @@
+{
+  "serverKey": "applovin-reporting",
+  "displayName": "AppLovin Reporting",
+  "packageName": "@feedmob/applovin-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/applovin-reporting"]
+  },
+  "env": [
+    {
+      "name": "APPLOVIN_API_KEY",
+      "label": "APPLOVIN_API_KEY",
+      "description": "AppLovin Reporting API key",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/appsamurai-reporting.json
+++ b/scripts/servers/appsamurai-reporting.json
@@ -1,0 +1,25 @@
+{
+  "serverKey": "appsamurai-reporting",
+  "displayName": "AppSamurai Reporting",
+  "packageName": "@feedmob/appsamurai-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/appsamurai-reporting"]
+  },
+  "env": [
+    {
+      "name": "APPSAMURAI_API_KEY",
+      "label": "APPSAMURAI_API_KEY",
+      "description": "AppSamurai Campaign Spend API key",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/civitai-records.json
+++ b/scripts/servers/civitai-records.json
@@ -1,0 +1,33 @@
+{
+  "serverKey": "civitai-records",
+  "displayName": "Civitai Records",
+  "packageName": "@feedmob/civitai-records",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/civitai-records"]
+  },
+  "env": [
+    {
+      "name": "DATABASE_URL",
+      "label": "DATABASE_URL",
+      "description": "PostgreSQL connection string for the Civitai records database",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "CIVITAI_ACCOUNT",
+      "label": "CIVITAI_ACCOUNT",
+      "description": "Optional Civitai account identifier",
+      "required": false,
+      "secret": false,
+      "default": "c29"
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/feedmob-reporting.json
+++ b/scripts/servers/feedmob-reporting.json
@@ -1,0 +1,39 @@
+{
+  "serverKey": "feedmob-reporting",
+  "displayName": "FeedMob Reporting",
+  "packageName": "@feedmob/feedmob-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/feedmob-reporting"]
+  },
+  "env": [
+    {
+      "name": "FEEDMOB_API_BASE",
+      "label": "FEEDMOB_API_BASE",
+      "description": "FeedMob Admin API base URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "FEEDMOB_KEY",
+      "label": "FEEDMOB_KEY",
+      "description": "FeedMob API key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "FEEDMOB_SECRET",
+      "label": "FEEDMOB_SECRET",
+      "description": "FeedMob API secret",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/femini-reporting.json
+++ b/scripts/servers/femini-reporting.json
@@ -1,0 +1,53 @@
+{
+  "serverKey": "femini-reporting",
+  "displayName": "Femini Reporting",
+  "packageName": "@feedmob/femini-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/femini-reporting"]
+  },
+  "env": [
+    {
+      "name": "FEMINI_API_URL",
+      "label": "FEMINI_API_URL",
+      "description": "Femini API base URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "FEMINI_API_TOKEN",
+      "label": "FEMINI_API_TOKEN",
+      "description": "Femini API bearer token",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "FEEDMOB_API_BASE",
+      "label": "FEEDMOB_API_BASE",
+      "description": "FeedMob Admin API base URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "FEEDMOB_KEY",
+      "label": "FEEDMOB_KEY",
+      "description": "FeedMob API key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "FEEDMOB_SECRET",
+      "label": "FEEDMOB_SECRET",
+      "description": "FeedMob API secret",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/github-issues.json
+++ b/scripts/servers/github-issues.json
@@ -1,0 +1,46 @@
+{
+  "serverKey": "github-issues",
+  "displayName": "GitHub Issues",
+  "packageName": "@feedmob/github-issues",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/github-issues"]
+  },
+  "env": [
+    {
+      "name": "GITHUB_PERSONAL_ACCESS_TOKEN",
+      "label": "GITHUB_PERSONAL_ACCESS_TOKEN",
+      "description": "GitHub personal access token",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "AI_API_URL",
+      "label": "AI_API_URL",
+      "description": "Optional FeedMob API endpoint for AI-backed issue features",
+      "required": false,
+      "secret": false
+    },
+    {
+      "name": "AI_API_TOKEN",
+      "label": "AI_API_TOKEN",
+      "description": "Optional bearer token for the FeedMob AI API",
+      "required": false,
+      "secret": true
+    },
+    {
+      "name": "GITHUB_DEFAULT_OWNER",
+      "label": "GITHUB_DEFAULT_OWNER",
+      "description": "Optional default GitHub owner or organization",
+      "required": false,
+      "secret": false
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/imagekit.json
+++ b/scripts/servers/imagekit.json
@@ -1,0 +1,46 @@
+{
+  "serverKey": "imagekit",
+  "displayName": "ImageKit",
+  "packageName": "@feedmob/imagekit",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/imagekit"]
+  },
+  "env": [
+    {
+      "name": "IMAGE_TOOL_API_KEY",
+      "label": "IMAGE_TOOL_API_KEY",
+      "description": "Image generation API key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "IMAGEKIT_PRIVATE_KEY",
+      "label": "IMAGEKIT_PRIVATE_KEY",
+      "description": "Optional ImageKit private key for upload support",
+      "required": false,
+      "secret": true
+    },
+    {
+      "name": "IMAGE_TOOL_BASE_URL",
+      "label": "IMAGE_TOOL_BASE_URL",
+      "description": "Optional image API base URL override",
+      "required": false,
+      "secret": false
+    },
+    {
+      "name": "IMAGE_TOOL_MODEL_ID",
+      "label": "IMAGE_TOOL_MODEL_ID",
+      "description": "Optional model ID override",
+      "required": false,
+      "secret": false
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/impact-radius-reporting.json
+++ b/scripts/servers/impact-radius-reporting.json
@@ -1,0 +1,53 @@
+{
+  "serverKey": "impact-radius-reporting",
+  "displayName": "Impact Radius Reporting",
+  "packageName": "@feedmob/impact-radius-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/impact-radius-reporting"]
+  },
+  "env": [
+    {
+      "name": "IMPACT_RADIUS_SID",
+      "label": "IMPACT_RADIUS_SID",
+      "description": "Impact Radius SID for basic authentication",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "IMPACT_RADIUS_TOKEN",
+      "label": "IMPACT_RADIUS_TOKEN",
+      "description": "Impact Radius token for basic authentication",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "FEEDMOB_API_BASE",
+      "label": "FEEDMOB_API_BASE",
+      "description": "FeedMob Admin API base URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "FEEDMOB_KEY",
+      "label": "FEEDMOB_KEY",
+      "description": "FeedMob API key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "FEEDMOB_SECRET",
+      "label": "FEEDMOB_SECRET",
+      "description": "FeedMob API secret",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/inmobi-reporting.json
+++ b/scripts/servers/inmobi-reporting.json
@@ -1,0 +1,60 @@
+{
+  "serverKey": "inmobi-reporting",
+  "displayName": "InMobi Reporting",
+  "packageName": "@feedmob/inmobi-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/inmobi-reporting"]
+  },
+  "env": [
+    {
+      "name": "INMOBI_AUTH_URL",
+      "label": "INMOBI_AUTH_URL",
+      "description": "InMobi auth endpoint URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "INMOBI_SKAN_REPORT_URL",
+      "label": "INMOBI_SKAN_REPORT_URL",
+      "description": "InMobi SKAN report endpoint URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "INMOBI_NON_SKAN_REPORT_URL",
+      "label": "INMOBI_NON_SKAN_REPORT_URL",
+      "description": "InMobi non-SKAN report endpoint URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "INMOBI_REPORT_BASE_URL",
+      "label": "INMOBI_REPORT_BASE_URL",
+      "description": "InMobi report base URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "INMOBI_CLIENT_ID",
+      "label": "INMOBI_CLIENT_ID",
+      "description": "InMobi client ID",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "INMOBI_CLIENT_SECRET",
+      "label": "INMOBI_CLIENT_SECRET",
+      "description": "InMobi client secret",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/iplocate.json
+++ b/scripts/servers/iplocate.json
@@ -1,0 +1,33 @@
+{
+  "serverKey": "iplocate",
+  "displayName": "IPLocate",
+  "packageName": "@feedmob/iplocate",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/iplocate"]
+  },
+  "env": [
+    {
+      "name": "IPLOCATE_API_KEY",
+      "label": "IPLOCATE_API_KEY",
+      "description": "IPLocate API key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "IPLOCATE_API_BASE",
+      "label": "IPLOCATE_API_BASE",
+      "description": "IPLocate API base URL",
+      "required": false,
+      "secret": false,
+      "default": "https://iplocate.feedmob.ai"
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/ironsource-aura-reporting.json
+++ b/scripts/servers/ironsource-aura-reporting.json
@@ -1,0 +1,32 @@
+{
+  "serverKey": "ironsource-aura-reporting",
+  "displayName": "IronSource Aura Reporting",
+  "packageName": "@feedmob/ironsource-aura-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/ironsource-aura-reporting"]
+  },
+  "env": [
+    {
+      "name": "IRONSOURCE_AURA_API_KEY",
+      "label": "IRONSOURCE_AURA_API_KEY",
+      "description": "IronSource Aura API key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "IRONSOURCE_AURA_API_BASE_URL",
+      "label": "IRONSOURCE_AURA_API_BASE_URL",
+      "description": "IronSource Aura API base URL",
+      "required": true,
+      "secret": false
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/ironsource-reporting.json
+++ b/scripts/servers/ironsource-reporting.json
@@ -1,0 +1,32 @@
+{
+  "serverKey": "ironsource-reporting",
+  "displayName": "IronSource Reporting",
+  "packageName": "@feedmob/ironsource-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/ironsource-reporting"]
+  },
+  "env": [
+    {
+      "name": "IRONSOURCE_SECRET_KEY",
+      "label": "IRONSOURCE_SECRET_KEY",
+      "description": "IronSource secret key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "IRONSOURCE_REFRESH_TOKEN",
+      "label": "IRONSOURCE_REFRESH_TOKEN",
+      "description": "IronSource refresh token",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/jampp-reporting.json
+++ b/scripts/servers/jampp-reporting.json
@@ -1,0 +1,32 @@
+{
+  "serverKey": "jampp-reporting",
+  "displayName": "Jampp Reporting",
+  "packageName": "@feedmob/jampp-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/jampp-reporting"]
+  },
+  "env": [
+    {
+      "name": "JAMPP_CLIENT_ID",
+      "label": "JAMPP_CLIENT_ID",
+      "description": "Jampp client ID",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "JAMPP_CLIENT_SECRET",
+      "label": "JAMPP_CLIENT_SECRET",
+      "description": "Jampp client secret",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/kayzen-reporting.json
+++ b/scripts/servers/kayzen-reporting.json
@@ -1,0 +1,47 @@
+{
+  "serverKey": "kayzen-reporting",
+  "displayName": "Kayzen Reporting",
+  "packageName": "@feedmob/kayzen-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/kayzen-reporting"]
+  },
+  "env": [
+    {
+      "name": "KAYZEN_USERNAME",
+      "label": "KAYZEN_USERNAME",
+      "description": "Kayzen username or email. Required unless KAYZEN_BASIC_AUTH is used.",
+      "required": false,
+      "secret": false
+    },
+    {
+      "name": "KAYZEN_PASSWORD",
+      "label": "KAYZEN_PASSWORD",
+      "description": "Kayzen password. Required unless KAYZEN_BASIC_AUTH is used.",
+      "required": false,
+      "secret": true
+    },
+    {
+      "name": "KAYZEN_BASIC_AUTH",
+      "label": "KAYZEN_BASIC_AUTH",
+      "description": "Optional precomputed basic auth token. If provided, username/password can be left empty.",
+      "required": false,
+      "secret": true
+    },
+    {
+      "name": "KAYZEN_BASE_URL",
+      "label": "KAYZEN_BASE_URL",
+      "description": "Kayzen API base URL",
+      "required": false,
+      "secret": false,
+      "default": "https://api.kayzen.io/v1"
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/liftoff-reporting.json
+++ b/scripts/servers/liftoff-reporting.json
@@ -1,0 +1,32 @@
+{
+  "serverKey": "liftoff-reporting",
+  "displayName": "Liftoff Reporting",
+  "packageName": "@feedmob/liftoff-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/liftoff-reporting"]
+  },
+  "env": [
+    {
+      "name": "LIFTOFF_API_KEY",
+      "label": "LIFTOFF_API_KEY",
+      "description": "Liftoff API key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "LIFTOFF_API_SECRET",
+      "label": "LIFTOFF_API_SECRET",
+      "description": "Liftoff API secret",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/mintegral-reporting.json
+++ b/scripts/servers/mintegral-reporting.json
@@ -1,0 +1,32 @@
+{
+  "serverKey": "mintegral-reporting",
+  "displayName": "Mintegral Reporting",
+  "packageName": "@feedmob/mintegral-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/mintegral-reporting"]
+  },
+  "env": [
+    {
+      "name": "MINTEGRAL_ACCESS_KEY",
+      "label": "MINTEGRAL_ACCESS_KEY",
+      "description": "Mintegral access key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "MINTEGRAL_API_KEY",
+      "label": "MINTEGRAL_API_KEY",
+      "description": "Mintegral API key",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/rtb-house-reporting.json
+++ b/scripts/servers/rtb-house-reporting.json
@@ -1,0 +1,32 @@
+{
+  "serverKey": "rtb-house-reporting",
+  "displayName": "RTB House Reporting",
+  "packageName": "@feedmob/rtb-house-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/rtb-house-reporting"]
+  },
+  "env": [
+    {
+      "name": "RTB_HOUSE_USER",
+      "label": "RTB_HOUSE_USER",
+      "description": "RTB House API username",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "RTB_HOUSE_PASSWORD",
+      "label": "RTB_HOUSE_PASSWORD",
+      "description": "RTB House API password",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/samsung-reporting.json
+++ b/scripts/servers/samsung-reporting.json
@@ -1,0 +1,40 @@
+{
+  "serverKey": "samsung-reporting",
+  "displayName": "Samsung Reporting",
+  "packageName": "@feedmob/samsung-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/samsung-reporting"]
+  },
+  "env": [
+    {
+      "name": "SAMSUNG_ISS",
+      "label": "SAMSUNG_ISS",
+      "description": "Samsung issuer value for JWT authentication",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "SAMSUNG_PRIVATE_KEY",
+      "label": "SAMSUNG_PRIVATE_KEY",
+      "description": "Samsung private key for JWT signing. Use a single-line or escaped PEM string in the current installer.",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "SAMSUNG_BASE_URL",
+      "label": "SAMSUNG_BASE_URL",
+      "description": "Samsung API base URL",
+      "required": false,
+      "secret": false,
+      "default": "https://devapi.samsungapps.com"
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/sensor-tower-reporting.json
+++ b/scripts/servers/sensor-tower-reporting.json
@@ -1,0 +1,33 @@
+{
+  "serverKey": "sensor-tower-reporting",
+  "displayName": "Sensor Tower Reporting",
+  "packageName": "@feedmob/sensor-tower-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/sensor-tower-reporting"]
+  },
+  "env": [
+    {
+      "name": "AUTH_TOKEN",
+      "label": "AUTH_TOKEN",
+      "description": "Sensor Tower API auth token",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "SENSOR_TOWER_BASE_URL",
+      "label": "SENSOR_TOWER_BASE_URL",
+      "description": "Sensor Tower API base URL",
+      "required": false,
+      "secret": false,
+      "default": "https://api.sensortower.com"
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/singular-reporting.json
+++ b/scripts/servers/singular-reporting.json
@@ -1,0 +1,32 @@
+{
+  "serverKey": "singular-reporting",
+  "displayName": "Singular Reporting",
+  "packageName": "@feedmob/singular-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/singular-reporting"]
+  },
+  "env": [
+    {
+      "name": "SINGULAR_API_KEY",
+      "label": "SINGULAR_API_KEY",
+      "description": "Singular API key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "SINGULAR_API_BASE_URL",
+      "label": "SINGULAR_API_BASE_URL",
+      "description": "Singular Reporting API base URL",
+      "required": true,
+      "secret": false
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/smadex-reporting.json
+++ b/scripts/servers/smadex-reporting.json
@@ -1,0 +1,39 @@
+{
+  "serverKey": "smadex-reporting",
+  "displayName": "Smadex Reporting",
+  "packageName": "@feedmob/smadex-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/smadex-reporting"]
+  },
+  "env": [
+    {
+      "name": "SMADEX_API_BASE_URL",
+      "label": "SMADEX_API_BASE_URL",
+      "description": "Smadex API base URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "SMADEX_EMAIL",
+      "label": "SMADEX_EMAIL",
+      "description": "Smadex login email",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "SMADEX_PASSWORD",
+      "label": "SMADEX_PASSWORD",
+      "description": "Smadex login password",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/tapjoy-reporting.json
+++ b/scripts/servers/tapjoy-reporting.json
@@ -1,0 +1,25 @@
+{
+  "serverKey": "tapjoy-reporting",
+  "displayName": "Tapjoy Reporting",
+  "packageName": "@feedmob/tapjoy-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/tapjoy-reporting"]
+  },
+  "env": [
+    {
+      "name": "TAPJOY_API_KEY",
+      "label": "TAPJOY_API_KEY",
+      "description": "Tapjoy API key or base64-encoded credentials, depending on your account setup",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/user-activity-reporting.json
+++ b/scripts/servers/user-activity-reporting.json
@@ -1,0 +1,53 @@
+{
+  "serverKey": "user-activity-reporting",
+  "displayName": "User Activity Reporting",
+  "packageName": "@feedmob/user-activity-reporting",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/user-activity-reporting"]
+  },
+  "env": [
+    {
+      "name": "FEEDMOB_API_BASE",
+      "label": "FEEDMOB_API_BASE",
+      "description": "FeedMob Admin API base URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "FEEDMOB_KEY",
+      "label": "FEEDMOB_KEY",
+      "description": "FeedMob API key",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "FEEDMOB_SECRET",
+      "label": "FEEDMOB_SECRET",
+      "description": "FeedMob API secret",
+      "required": true,
+      "secret": true
+    },
+    {
+      "name": "SLACK_BOT_TOKEN",
+      "label": "SLACK_BOT_TOKEN",
+      "description": "Optional Slack bot token for message search",
+      "required": false,
+      "secret": true
+    },
+    {
+      "name": "HUBSPOT_ACCESS_TOKEN",
+      "label": "HUBSPOT_ACCESS_TOKEN",
+      "description": "Optional HubSpot access token",
+      "required": false,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}

--- a/scripts/servers/work-journals.json
+++ b/scripts/servers/work-journals.json
@@ -1,0 +1,32 @@
+{
+  "serverKey": "work-journals",
+  "displayName": "Work Journals",
+  "packageName": "@feedmob/work-journals",
+  "command": {
+    "type": "npx",
+    "args": ["-y", "@feedmob/work-journals"]
+  },
+  "env": [
+    {
+      "name": "API_URL",
+      "label": "API_URL",
+      "description": "Work Journals API base URL",
+      "required": true,
+      "secret": false
+    },
+    {
+      "name": "API_TOKEN",
+      "label": "API_TOKEN",
+      "description": "Work Journals API token",
+      "required": true,
+      "secret": true
+    }
+  ],
+  "macos": {
+    "injectPath": true
+  },
+  "postInstallMessage": [
+    "Fully quit Claude Desktop",
+    "Reopen Claude Desktop to load the MCP server"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR replaces the single-package Sensor Tower installer flow with a metadata-driven installer framework for FeedMob MCP servers.

## What changed

- parameterized `scripts/install.sh` and `scripts/install.ps1` to install a server by `serverKey`
- added `scripts/servers/*.json` metadata for all 24 MCP CLI packages in the repository
- updated `scripts/README.md` to describe the unified installer workflow in English
- preserved macOS PATH injection and Windows-specific installer behavior

## Why

The previous installer scripts were hard-coded to `sensor-tower-reporting`, which made the repository difficult to scale as more MCP servers were added. A metadata-driven approach keeps the installer logic centralized while allowing each server to define its own environment variable prompts and package details.

## Impact

- users can list installable servers and install a specific server through the shared installer entry points
- new MCP servers can be added by contributing metadata instead of duplicating installer logic
- installer documentation now matches the current multi-server behavior

## Validation

- `bash -n scripts/install.sh`
- verified `bash scripts/install.sh --list` output
- verified `scripts/servers/*.json` parse successfully
- verified metadata coverage matches all 24 CLI packages in `src/*/package.json`

## Notes

- interactive end-to-end installer runs were started but not completed in this change set
- PowerShell syntax was not executed in a live `pwsh` environment during this pass

https://github.com/feed-mob/tracking_admin/issues/22015
