### PR TITLE
[codex] add per-server curl install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,33 @@ MCP (Model Context Protocol) servers provide structured data and context to AI m
 ## 📖 Documentation
 Each server implementation includes its own detailed documentation in its respective directory.
 
+## ⚡ Installation
+
+Each MCP server README now includes its own dedicated install command, for example:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- sensor-tower-reporting
+```
+
+To discover available server keys from this repository:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- --list
+```
+
+For pinned installs:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- sensor-tower-reporting
+```
+
+If you want to review the installer before running it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | less
+```
+
 
 ## 🤝 Contributing
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,20 @@ bash scripts/install.sh --list
 bash scripts/install.sh sensor-tower-reporting
 ```
 
+### Direct from GitHub
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- --list
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- sensor-tower-reporting
+```
+
+Pin a specific release or tag:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- sensor-tower-reporting
+```
+
 ### Windows
 
 ```powershell
@@ -66,4 +80,6 @@ Structure:
 
 - The macOS installer explicitly injects `PATH` because Claude Desktop usually does not inherit the full shell `PATH`.
 - The Windows installer does not inject `PATH` by default.
-- The first version does not yet support `--all`, version pinning, remote metadata fetching, or `multiline` interactive input.
+- The shell installer now supports direct execution from GitHub by fetching `scripts/servers/<server>.json` remotely when local metadata is unavailable.
+- Use `FM_MCP_INSTALL_REF` to pin a release tag and `FM_MCP_INSTALL_REPO` to point at a fork.
+- The installer still does not support `--all` or `multiline` interactive input.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,12 +9,18 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 CONFIG_FILE="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-$0}"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)"
 SERVERS_DIR="$SCRIPT_DIR/servers"
 MACOS_PATH_VALUE="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+REMOTE_REPO="${FM_MCP_INSTALL_REPO:-feed-mob/fm-mcp-servers}"
+REMOTE_REF="${FM_MCP_INSTALL_REF:-main}"
+REMOTE_RAW_BASE_URL="https://raw.githubusercontent.com/$REMOTE_REPO/$REMOTE_REF/scripts/servers"
+REMOTE_API_URL="https://api.github.com/repos/$REMOTE_REPO/contents/scripts/servers?ref=$REMOTE_REF"
 
 SERVER_KEY="${1:-}"
 METADATA_FILE=""
+METADATA_TEMP_FILE=""
 DISPLAY_NAME=""
 PACKAGE_NAME=""
 COMMAND_TYPE=""
@@ -56,24 +62,82 @@ Usage:
 Examples:
   bash scripts/install.sh sensor-tower-reporting
   bash scripts/install.sh applovin-reporting
+
+Remote install examples:
+  curl -fsSL https://raw.githubusercontent.com/$REMOTE_REPO/$REMOTE_REF/scripts/install.sh | bash -s -- --list
+  curl -fsSL https://raw.githubusercontent.com/$REMOTE_REPO/$REMOTE_REF/scripts/install.sh | bash -s -- sensor-tower-reporting
+
+Environment overrides:
+  FM_MCP_INSTALL_REPO=feed-mob/fm-mcp-servers
+  FM_MCP_INSTALL_REF=main
 EOF
 }
 
 list_servers() {
   print_section "Available MCP Servers"
-  if ! find "$SERVERS_DIR" -maxdepth 1 -name '*.json' | grep -q .; then
-    print_warning "No server metadata found in $SERVERS_DIR"
+  if [[ -d "$SERVERS_DIR" ]] && find "$SERVERS_DIR" -maxdepth 1 -name '*.json' 2>/dev/null | grep -q .; then
+    while IFS= read -r file; do
+      local key name pkg
+      key=$(jq -r '.serverKey' "$file")
+      name=$(jq -r '.displayName' "$file")
+      pkg=$(jq -r '.packageName' "$file")
+      echo "  - $key"
+      echo "    $name ($pkg)"
+    done < <(find "$SERVERS_DIR" -maxdepth 1 -name '*.json' | sort)
     return
   fi
 
-  while IFS= read -r file; do
-    local key name pkg
-    key=$(jq -r '.serverKey' "$file")
-    name=$(jq -r '.displayName' "$file")
-    pkg=$(jq -r '.packageName' "$file")
-    echo "  - $key"
-    echo "    $name ($pkg)"
-  done < <(find "$SERVERS_DIR" -maxdepth 1 -name '*.json' | sort)
+  if ! command -v curl >/dev/null 2>&1; then
+    print_error "curl is required to list remote servers"
+    exit 1
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    print_error "jq is required to list remote servers"
+    exit 1
+  fi
+
+  print_warning "Local metadata not found. Listing server keys from $REMOTE_REPO@$REMOTE_REF"
+  local response
+  response=$(curl -fsSL "$REMOTE_API_URL") || {
+    print_error "Failed to fetch remote server list"
+    exit 1
+  }
+
+  if [[ "$(jq -r 'type' <<<"$response")" != "array" ]]; then
+    print_error "Unexpected response while fetching remote server list"
+    exit 1
+  fi
+
+  jq -r '.[] | select(.name | endswith(".json")) | "  - " + (.name | sub("\\.json$"; ""))' <<<"$response"
+}
+
+fetch_remote_metadata() {
+  if ! command -v curl >/dev/null 2>&1; then
+    print_error "curl is required for direct remote installation"
+    exit 1
+  fi
+
+  METADATA_TEMP_FILE=$(mktemp)
+  if ! curl -fsSL "$REMOTE_RAW_BASE_URL/$SERVER_KEY.json" -o "$METADATA_TEMP_FILE"; then
+    rm -f "$METADATA_TEMP_FILE"
+    METADATA_TEMP_FILE=""
+    print_error "Unknown server: $SERVER_KEY"
+    echo ""
+    usage
+    echo ""
+    list_servers
+    exit 1
+  fi
+
+  if ! jq empty "$METADATA_TEMP_FILE" 2>/dev/null; then
+    rm -f "$METADATA_TEMP_FILE"
+    METADATA_TEMP_FILE=""
+    print_error "Fetched metadata is not valid JSON: $SERVER_KEY"
+    exit 1
+  fi
+
+  METADATA_FILE="$METADATA_TEMP_FILE"
 }
 
 validate_args() {
@@ -88,14 +152,11 @@ validate_args() {
   fi
 
   METADATA_FILE="$SERVERS_DIR/$SERVER_KEY.json"
-  if [[ ! -f "$METADATA_FILE" ]]; then
-    print_error "Unknown server: $SERVER_KEY"
-    echo ""
-    usage
-    echo ""
-    list_servers
-    exit 1
+  if [[ -f "$METADATA_FILE" ]]; then
+    return
   fi
+
+  fetch_remote_metadata
 }
 
 load_metadata() {
@@ -403,6 +464,7 @@ print_completion() {
 }
 
 main() {
+  trap 'rm -f "$METADATA_TEMP_FILE"' EXIT
   validate_args
   load_metadata
   print_banner

--- a/src/applovin-reporting/README.md
+++ b/src/applovin-reporting/README.md
@@ -1,5 +1,18 @@
 # AppLovin Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- applovin-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- applovin-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for [AppLovin Reporting API](https://dash.applovin.com/documentation/mediation/reporting-api).
 
 ## Features

--- a/src/appsamurai-reporting/README.md
+++ b/src/appsamurai-reporting/README.md
@@ -1,5 +1,18 @@
 # AppSamurai Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- appsamurai-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- appsamurai-reporting
+```
+
 This MCP server provides tools and prompts to interact with the [AppSamurai Campaign Spend API](https://help.appsamurai.com/en/articles/11105087-appsamurai-campaign-spend-api).
 
 ## Features

--- a/src/civitai-records/README.md
+++ b/src/civitai-records/README.md
@@ -1,5 +1,18 @@
 # FeedMob Civitai Records MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- civitai-records
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- civitai-records
+```
+
 MCP server for managing Civitai content workflows including prompts, assets (images/videos), and publication records. Tracks the full lifecycle from content generation to Civitai publication with support for many-to-many associations between posts, assets, and prompts.
 
 ## Prerequisites

--- a/src/feedmob-reporting/README.md
+++ b/src/feedmob-reporting/README.md
@@ -1,5 +1,18 @@
 # Feedmob Spend MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- feedmob-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- feedmob-reporting
+```
+
 
 ## Usage with Claude Desktop
 

--- a/src/femini-reporting/README.md
+++ b/src/femini-reporting/README.md
@@ -1,5 +1,18 @@
 # Feedmob Femini MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- femini-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- femini-reporting
+```
+
 ## Features
 
 - 🔍 **Flexible Data Querying**: Supports various grouping methods and filtering conditions

--- a/src/github-issues/README.md
+++ b/src/github-issues/README.md
@@ -1,5 +1,18 @@
 # FeedMob GitHub Issues MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- github-issues
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- github-issues
+```
+
 A GitHub Issues MCP server customized for the FeedMob team.
 
 ## Prerequisites

--- a/src/imagekit/README.md
+++ b/src/imagekit/README.md
@@ -1,5 +1,18 @@
 # FeedMob ImageKit MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- imagekit
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- imagekit
+```
+
 Lightweight Model Context Protocol server that exposes ImageKit-related tooling via the FeedMob internal MCP stack. The starter implementation currently publishes a single arithmetic helper and is intended as a template for richer ImageKit automation.
 
 ## Prerequisites

--- a/src/impact-radius-reporting/README.md
+++ b/src/impact-radius-reporting/README.md
@@ -1,5 +1,18 @@
 # Impact Radius Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- impact-radius-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- impact-radius-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for [Impact Radius](https://impact.com/) affiliate marketing reporting with FeedMob campaign mapping integration.
 
 ## Features

--- a/src/inmobi-reporting/README.md
+++ b/src/inmobi-reporting/README.md
@@ -1,5 +1,18 @@
 # Inmobi Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- inmobi-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- inmobi-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for Inmobi Reporting API.
 
 ## Features

--- a/src/iplocate/README.md
+++ b/src/iplocate/README.md
@@ -1,5 +1,18 @@
 # IPLocate MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- iplocate
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- iplocate
+```
+
 MCP Server for the IPLocate API, providing IP geolocation and fraud detection capabilities through Claude and other MCP-compatible clients.
 
 ## Features

--- a/src/ironsource-aura-reporting/README.md
+++ b/src/ironsource-aura-reporting/README.md
@@ -1,5 +1,18 @@
 # IronSource Aura Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- ironsource-aura-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- ironsource-aura-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for IronSource Aura Reporting API for advertisers.
 
 ## Features

--- a/src/ironsource-reporting/README.md
+++ b/src/ironsource-reporting/README.md
@@ -1,5 +1,18 @@
 # IronSource Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- ironsource-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- ironsource-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for IronSource Reporting API for advertisers.
 
 ## Features

--- a/src/jampp-reporting/README.md
+++ b/src/jampp-reporting/README.md
@@ -1,5 +1,18 @@
 # Jampp Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- jampp-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- jampp-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for [Jampp Reporting API](https://developers.jampp.com/docs/reporting-api).
 
 

--- a/src/kayzen-reporting/README.md
+++ b/src/kayzen-reporting/README.md
@@ -1,5 +1,18 @@
 # Kayzen Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- kayzen-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- kayzen-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for [Kayzen Reporting API](https://developers.kayzen.io/reference/list-reports).
 
 

--- a/src/liftoff-reporting/README.md
+++ b/src/liftoff-reporting/README.md
@@ -1,5 +1,18 @@
 # Liftoff Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- liftoff-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- liftoff-reporting
+```
+
 This MCP server provides tools to interact with the [Liftoff Reporting API](https://docs.liftoff.io/advertiser/reporting_api).
 
 ## Features

--- a/src/mintegral-reporting/README.md
+++ b/src/mintegral-reporting/README.md
@@ -1,5 +1,18 @@
 # Mintegral Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- mintegral-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- mintegral-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for Mintegral Reporting API.
 
 ## Features

--- a/src/rtb-house-reporting/README.md
+++ b/src/rtb-house-reporting/README.md
@@ -1,5 +1,18 @@
 # RTB House Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- rtb-house-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- rtb-house-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for RTB House API.
 
 ## Features

--- a/src/samsung-reporting/README.md
+++ b/src/samsung-reporting/README.md
@@ -1,5 +1,18 @@
 # Samsung Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- samsung-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- samsung-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for Samsung API.
 
 ## Features

--- a/src/sensor-tower-reporting/README.md
+++ b/src/sensor-tower-reporting/README.md
@@ -1,5 +1,18 @@
 # Sensor Tower Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- sensor-tower-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- sensor-tower-reporting
+```
+
 This MCP server provides tools to interact with the [Sensor Tower API](https://sensortower.com/api) for mobile app intelligence and market data.
 
 ## Features

--- a/src/singular-reporting/README.md
+++ b/src/singular-reporting/README.md
@@ -1,5 +1,18 @@
 # Singular Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- singular-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- singular-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for [Singular Reporting](https://support.singular.net/hc/en-us/articles/360045245692-Reporting-API-Reference).
 
 

--- a/src/smadex-reporting/README.md
+++ b/src/smadex-reporting/README.md
@@ -1,5 +1,18 @@
 # Smadex Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- smadex-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- smadex-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for Smadex Reporting API.
 
 ## Features

--- a/src/tapjoy-reporting/README.md
+++ b/src/tapjoy-reporting/README.md
@@ -1,5 +1,18 @@
 # TapJoy Reporting MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- tapjoy-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- tapjoy-reporting
+```
+
 Node.js server implementing Model Context Protocol (MCP) for [TapJoy Reporting API](https://api.tapjoy.com/graphql/docs/guide-getting_started).
 
 ## Features

--- a/src/user-activity-reporting/README.md
+++ b/src/user-activity-reporting/README.md
@@ -1,5 +1,18 @@
 # User Activity Reporting MCP
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- user-activity-reporting
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- user-activity-reporting
+```
+
 MCP server for querying client contacts, Slack messages, and HubSpot tickets.
 
 ## Features

--- a/src/work-journals/README.md
+++ b/src/work-journals/README.md
@@ -1,5 +1,18 @@
 # Feedmob Work Journals MCP Server
 
+## Install with Claude Desktop
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/main/scripts/install.sh | bash -s -- work-journals
+```
+
+Pin a specific release:
+
+```bash
+FM_MCP_INSTALL_REF=v1.0.0 \
+curl -fsSL https://raw.githubusercontent.com/feed-mob/fm-mcp-servers/v1.0.0/scripts/install.sh | bash -s -- work-journals
+```
+
 ## Features
 
 *   📝 **Work Journal Management**: Supports querying, creating, and updating work journals.


### PR DESCRIPTION
## What changed

- added direct `curl` installer support to `scripts/install.sh` by fetching remote server metadata when local metadata is unavailable
- documented remote installer usage and version pinning in the root installer docs
- added a dedicated Claude Desktop install command to each MCP server README so every server has its own copy-pasteable `curl` command
- updated the root README to point users to per-server install instructions while keeping repository-level discovery commands

## Why

The installer previously depended on local `scripts/servers/*.json` metadata, so `curl | bash` did not work when the script was executed directly from GitHub. At the same time, install instructions were centralized in the root README instead of living with each MCP server.

## Impact

- users can install a server directly from GitHub with `curl -fsSL .../scripts/install.sh | bash -s -- <server-key>`
- each MCP server README now exposes its own server-specific install command
- the installer can list and resolve servers in both local-clone and remote-script execution modes

## Validation

- `bash -n scripts/install.sh`
- `bash scripts/install.sh --list`
- `cat scripts/install.sh | bash -s -- --list`

https://github.com/feed-mob/tracking_admin/issues/22015
