### PR TITLE
[codex] fix macOS bash 3 installer compatibility

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -170,7 +170,10 @@ load_metadata() {
     exit 1
   fi
 
-  mapfile -t POST_INSTALL_MESSAGES < <(jq -r '.postInstallMessage[]?' "$METADATA_FILE")
+  POST_INSTALL_MESSAGES=()
+  while IFS= read -r message; do
+    POST_INSTALL_MESSAGES+=("$message")
+  done < <(jq -r '.postInstallMessage[]?' "$METADATA_FILE")
 }
 
 print_banner() {


### PR DESCRIPTION
## What changed

- replaced `mapfile` in `scripts/install.sh` with a Bash 3 compatible loop so the installer works with macOS' default Bash
- keeps the direct GitHub installer flow working for per-server README install commands

## Why

The direct installer command failed on macOS systems that still use Bash 3.2 by default because `mapfile` is not available there.

## Impact

- `curl -fsSL .../scripts/install.sh | bash -s -- sensor-tower-reporting` now works on default macOS Bash without requiring users to install a newer shell

## Validation

- `bash --version`
- `bash -n scripts/install.sh`
- `cat scripts/install.sh | bash -s -- --list`

https://github.com/feed-mob/tracking_admin/issues/22015
