### PR TITLE
[codex] Add Sensor Tower API usage tool

### DIFF
--- a/src/sensor-tower-reporting/README.md
+++ b/src/sensor-tower-reporting/README.md
@@ -29,6 +29,7 @@ This MCP server provides tools to interact with the [Sensor Tower API](https://s
   - [`get_retention`](src/index.ts:1592): Get app retention data (day 1 to day 90)
   - [`get_downloads_by_sources`](src/index.ts:1662): Fetch app downloads by sources (organic, paid, browser)
   - [`find_apps_by_metric_threshold`](src/index.ts:1733): Discover apps exceeding a download/revenue threshold over a given time period and geography
+  - `get_api_usage`: Return the latest observed `x-api-usage-limit` and `x-api-usage-count` headers cached by the MCP process
 - **Built-in API Safeguards**:
   - Shared request client for all Sensor Tower endpoints
   - Default request pacing of `5` requests per second to stay under the documented `6 req/s` cap
@@ -179,6 +180,7 @@ The server includes comprehensive error handling with specific error types:
 - Monthly usage is refreshed from Sensor Tower's response headers whenever available.
 - When remaining monthly quota drops below the warning threshold, tool responses include an `api_usage.warning`.
 - When remaining monthly quota drops below the block threshold, new requests are rejected instead of fully exhausting the account.
+- `get_api_usage` returns the most recently observed usage headers without consuming an extra Sensor Tower API request.
 
 ## Development
 

--- a/src/sensor-tower-reporting/src/index.ts
+++ b/src/sensor-tower-reporting/src/index.ts
@@ -825,6 +825,21 @@ function getApiUsageSummary(): ApiUsageSummary | undefined {
   return sensorTowerService?.getUsageSummary();
 }
 
+function formatApiUsageResponse() {
+  const apiUsage = getApiUsageSummary();
+
+  return {
+    api_usage_limit: apiUsage?.limit ?? null,
+    api_usage_count: apiUsage?.used ?? null,
+    api_usage_remaining: apiUsage?.remaining ?? null,
+    api_usage_warning: apiUsage?.warning,
+    last_updated_at: apiUsage?.lastUpdatedAt,
+    source: apiUsage?.used === null
+      ? "No Sensor Tower response headers have been observed in this MCP process yet."
+      : "Values sourced from the latest observed Sensor Tower response headers."
+  };
+}
+
 // Input validation schemas
 const osSchema = z.string()
   .refine(val => ['ios', 'android'].includes(val.toLowerCase()), "OS must be 'ios' or 'android'")
@@ -941,6 +956,41 @@ const minValueSchema = z.number().optional()
 
 const limitLargeSchema = z.number().min(1).max(2000).optional().default(100)
   .describe("Max number of apps to fetch from the API (1–2000). Defaults to 100. Use higher values with min_value to filter large result sets.");
+
+// Tool: Get API Usage
+server.tool("get_api_usage",
+  "Returns the latest observed Sensor Tower API usage headers captured by this MCP process.",
+  {},
+  async () => {
+    try {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(formatApiUsageResponse(), null, 2)
+          }
+        ]
+      };
+    } catch (error: any) {
+      const errorMessage = `Error fetching Sensor Tower API usage: ${error.message}`;
+      console.error(errorMessage);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: errorMessage,
+              ...formatApiUsageResponse(),
+              timestamp: new Date().toISOString()
+            }, null, 2)
+          }
+        ],
+        isError: true
+      };
+    }
+  }
+);
 
 // Tool: Get App Metadata
 server.tool("get_app_metadata",


### PR DESCRIPTION
## Summary
- add a get_api_usage tool that returns the latest observed Sensor Tower x-api-usage-limit and x-api-usage-count headers
- surface cached usage details without consuming an extra Sensor Tower API request
- document the new tool in the sensor-tower-reporting README

## Validation
- npm run build (in src/sensor-tower-reporting)

https://github.com/feed-mob/tracking_admin/issues/22222