### PR TITLE
[codex] Add Sensor Tower API usage tool and version bump

### DIFF
--- a/src/sensor-tower-reporting/package-lock.json
+++ b/src/sensor-tower-reporting/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@feedmob/sensor-tower-reporting",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@feedmob/sensor-tower-reporting",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.7.0",
         "dotenv": "^16.4.7",

--- a/src/sensor-tower-reporting/package.json
+++ b/src/sensor-tower-reporting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feedmob/sensor-tower-reporting",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "MCP server for sensor-tower API",
   "main": "dist/index.js",
   "author": "FeedMob",

--- a/src/sensor-tower-reporting/src/index.ts
+++ b/src/sensor-tower-reporting/src/index.ts
@@ -13,7 +13,7 @@ dotenv.config();
 
 const server = new McpServer({
   name: "Sensor Tower Reporting MCP Server",
-  version: "0.1.4"
+  version: "0.1.6"
 });
 
 const SENSOR_TOWER_BASE_URL = process.env.SENSOR_TOWER_BASE_URL || 'https://api.sensortower.com';


### PR DESCRIPTION
## Summary
- add a get_api_usage tool that exposes the latest observed Sensor Tower API usage headers
- keep usage reporting zero-cost by returning cached header values from the shared client
- bump sensor-tower-reporting to 0.1.6 so npm publish can succeed

## Validation
- npm run build (in src/sensor-tower-reporting)

https://github.com/feed-mob/tracking_admin/issues/22222