### PR TITLE
[codex] Refresh Sensor Tower API usage on demand

### DIFF
--- a/src/sensor-tower-reporting/README.md
+++ b/src/sensor-tower-reporting/README.md
@@ -29,7 +29,7 @@ This MCP server provides tools to interact with the [Sensor Tower API](https://s
   - [`get_retention`](src/index.ts:1592): Get app retention data (day 1 to day 90)
   - [`get_downloads_by_sources`](src/index.ts:1662): Fetch app downloads by sources (organic, paid, browser)
   - [`find_apps_by_metric_threshold`](src/index.ts:1733): Discover apps exceeding a download/revenue threshold over a given time period and geography
-  - `get_api_usage`: Return the latest observed `x-api-usage-limit` and `x-api-usage-count` headers cached by the MCP process
+  - `get_api_usage`: Return the latest observed `x-api-usage-limit` and `x-api-usage-count` headers, refreshing them with a lightweight Sensor Tower request if the current process has no cached values yet
 - **Built-in API Safeguards**:
   - Shared request client for all Sensor Tower endpoints
   - Default request pacing of `5` requests per second to stay under the documented `6 req/s` cap
@@ -180,7 +180,7 @@ The server includes comprehensive error handling with specific error types:
 - Monthly usage is refreshed from Sensor Tower's response headers whenever available.
 - When remaining monthly quota drops below the warning threshold, tool responses include an `api_usage.warning`.
 - When remaining monthly quota drops below the block threshold, new requests are rejected instead of fully exhausting the account.
-- `get_api_usage` returns the most recently observed usage headers without consuming an extra Sensor Tower API request.
+- `get_api_usage` returns cached usage headers when available, and otherwise performs one lightweight request to refresh the latest usage headers.
 
 ## Development
 

--- a/src/sensor-tower-reporting/package-lock.json
+++ b/src/sensor-tower-reporting/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@feedmob/sensor-tower-reporting",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@feedmob/sensor-tower-reporting",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.7.0",
         "dotenv": "^16.4.7",

--- a/src/sensor-tower-reporting/package.json
+++ b/src/sensor-tower-reporting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feedmob/sensor-tower-reporting",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "MCP server for sensor-tower API",
   "main": "dist/index.js",
   "author": "FeedMob",

--- a/src/sensor-tower-reporting/src/index.ts
+++ b/src/sensor-tower-reporting/src/index.ts
@@ -13,7 +13,7 @@ dotenv.config();
 
 const server = new McpServer({
   name: "Sensor Tower Reporting MCP Server",
-  version: "0.1.6"
+  version: "0.1.7"
 });
 
 const SENSOR_TOWER_BASE_URL = process.env.SENSOR_TOWER_BASE_URL || 'https://api.sensortower.com';
@@ -78,6 +78,10 @@ class SensorTowerApiService {
 
   getUsageSummary(): ApiUsageSummary {
     return this.client.getUsageSummary();
+  }
+
+  async refreshUsageSummaryIfNeeded(): Promise<ApiUsageSummary> {
+    return await this.client.refreshUsageHeaders();
   }
 
   /**
@@ -827,6 +831,7 @@ function getApiUsageSummary(): ApiUsageSummary | undefined {
 
 function formatApiUsageResponse() {
   const apiUsage = getApiUsageSummary();
+  const hasObservedUsageHeaders = apiUsage?.used !== null && apiUsage?.used !== undefined;
 
   return {
     api_usage_limit: apiUsage?.limit ?? null,
@@ -834,9 +839,9 @@ function formatApiUsageResponse() {
     api_usage_remaining: apiUsage?.remaining ?? null,
     api_usage_warning: apiUsage?.warning,
     last_updated_at: apiUsage?.lastUpdatedAt,
-    source: apiUsage?.used === null
-      ? "No Sensor Tower response headers have been observed in this MCP process yet."
-      : "Values sourced from the latest observed Sensor Tower response headers."
+    source: hasObservedUsageHeaders
+      ? "Values sourced from the latest observed Sensor Tower response headers."
+      : "No Sensor Tower response headers have been observed in this MCP process yet."
   };
 }
 
@@ -963,6 +968,9 @@ server.tool("get_api_usage",
   {},
   async () => {
     try {
+      const sensorTowerService = getSensorTowerService();
+      await sensorTowerService.refreshUsageSummaryIfNeeded();
+
       return {
         content: [
           {

--- a/src/sensor-tower-reporting/src/sensorTowerHttpClient.ts
+++ b/src/sensor-tower-reporting/src/sensorTowerHttpClient.ts
@@ -22,6 +22,10 @@ function sleep(ms: number): Promise<void> {
 export class SensorTowerHttpClient {
   private readonly rateLimiter: RateLimiter;
   private readonly usageBudget: UsageBudget;
+  private readonly usageRefreshQueryParams = new URLSearchParams({
+    app_ids: "284882215",
+    country: "US"
+  });
 
   constructor(private readonly options: SensorTowerHttpClientOptions) {
     this.rateLimiter = new RateLimiter(options.requestsPerSecond);
@@ -73,6 +77,27 @@ export class SensorTowerHttpClient {
   }
 
   getUsageSummary(): ApiUsageSummary {
+    return this.usageBudget.getSummary();
+  }
+
+  async refreshUsageHeaders(): Promise<ApiUsageSummary> {
+    const currentUsage = this.usageBudget.getSummary();
+    if (currentUsage.used !== null && currentUsage.used !== undefined) {
+      return currentUsage;
+    }
+
+    const queryParams = new URLSearchParams(this.usageRefreshQueryParams);
+    try {
+      await this.getJson<unknown>(
+        "/v1/ios/apps",
+        queryParams,
+        "api usage refresh"
+      );
+    } catch (error) {
+      console.error("Failed to refresh Sensor Tower API usage headers:", error);
+      throw error;
+    }
+
     return this.usageBudget.getSummary();
   }
 


### PR DESCRIPTION
## Summary
- update get_api_usage to return cached usage data when available and perform one lightweight Sensor Tower request when the current process has no cached headers yet
- keep the shared request client responsible for refreshing usage headers so the behavior is reusable
- bump sensor-tower-reporting to 0.1.7 and document the refreshed get_api_usage behavior

## Validation
- npm run build (in src/sensor-tower-reporting)

https://github.com/feed-mob/tracking_admin/issues/22222