### PR TITLE
[codex] Deprecate Sensor Tower reporting MCP

### DIFF
--- a/src/sensor-tower-reporting/package-lock.json
+++ b/src/sensor-tower-reporting/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@feedmob/sensor-tower-reporting",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@feedmob/sensor-tower-reporting",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.7.0",
         "dotenv": "^16.4.7",

--- a/src/sensor-tower-reporting/package.json
+++ b/src/sensor-tower-reporting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feedmob/sensor-tower-reporting",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "MCP server for sensor-tower API",
   "main": "dist/index.js",
   "author": "FeedMob",

--- a/src/sensor-tower-reporting/src/index.ts
+++ b/src/sensor-tower-reporting/src/index.ts
@@ -22,7 +22,7 @@ const deprecatedDescription = (description: string): string =>
 
 const server = new McpServer({
   name: "Sensor Tower Reporting MCP Server",
-  version: "0.1.7"
+  version: "0.1.8"
 }, {
   instructions: DEPRECATION_NOTICE
 });
@@ -973,10 +973,9 @@ const minValueSchema = z.number().optional()
 const limitLargeSchema = z.number().min(1).max(2000).optional().default(100)
   .describe("Max number of apps to fetch from the API (1–2000). Defaults to 100. Use higher values with min_value to filter large result sets.");
 
-<<<<<<< HEAD
 // Tool: Get API Usage
 server.tool("get_api_usage",
-  "Returns the latest observed Sensor Tower API usage headers captured by this MCP process.",
+  deprecatedDescription("Returns the latest observed Sensor Tower API usage headers captured by this MCP process."),
   {},
   async () => {
     try {
@@ -1010,7 +1009,8 @@ server.tool("get_api_usage",
       };
     }
   }
-=======
+);
+
 // Prompt: Deprecation Notice
 server.prompt(
   "deprecation_notice",
@@ -1025,7 +1025,6 @@ server.prompt(
       }
     }]
   })
->>>>>>> d3727ac (Deprecate sensortower-reporting mcp)
 );
 
 // Tool: Get App Metadata


### PR DESCRIPTION
## Summary

- Mark `sensor-tower-reporting` as deprecated and point users to the hosted SensorTower MCP endpoint.
- Surface the migration notice through MCP instructions, tool descriptions, startup logs, README docs, and installer metadata.
- Teach the macOS and Windows installers to display manifest-level deprecation notices.
- Bump `@feedmob/sensor-tower-reporting` to `0.1.8` and remove stale conflict markers from the server entrypoint.



https://github.com/feed-mob/tracking_admin/issues/22225
