### PR TITLE
feat(feedmob-reporting): pass campaign on-behalf user

### DIFF
--- a/src/feedmob-reporting/src/api.ts
+++ b/src/feedmob-reporting/src/api.ts
@@ -1419,7 +1419,8 @@ export async function createCampaign(
   app_info_id: number,
   os: string,
   client_id: number,
-  client_uuid: string
+  client_uuid: string,
+  on_behalf_of_user_id?: number
 ): Promise<any> {
   const url = `${FEEDMOB_API_BASE}/ai/api/campaigns`;
 
@@ -1430,7 +1431,8 @@ export async function createCampaign(
       app_info_id,
       os,
       client_id,
-      client_uuid
+      client_uuid,
+      on_behalf_of_user_id
     }, {
       headers: {
         'Content-Type': 'application/json',

--- a/src/feedmob-reporting/src/index.ts
+++ b/src/feedmob-reporting/src/index.ts
@@ -915,6 +915,7 @@ server.tool(
     os: z.string().describe("Operating system: 'Android', 'iOS', or 'Universal'"),
     client_id: z.number().describe("Client ID"),
     client_uuid: z.string().describe("Client UUID"),
+    on_behalf_of_user_id: z.number().optional().describe("FeedMob user ID to include in the campaign creation audit comment"),
   },
   async (params) => {
     try {
@@ -923,7 +924,8 @@ server.tool(
         params.app_info_id,
         params.os,
         params.client_id,
-        params.client_uuid
+        params.client_uuid,
+        params.on_behalf_of_user_id
       );
       const formattedData = JSON.stringify(data, null, 2);
       return {


### PR DESCRIPTION
## Summary
- Add optional `on_behalf_of_user_id` to the `create_campaign` MCP tool schema
- Forward `on_behalf_of_user_id` to FeedMob Admin campaign creation

## Testing
- `npm run build`

## Notes
- `cog verify` passed for the new commit message
- Repository-wide `cog check` fails on historical commits unrelated to this branch