### PR TITLE
feat(samsung-reporting): add Albert client support and improve documentation

### DIFF
--- a/src/samsung-reporting/README.md
+++ b/src/samsung-reporting/README.md
@@ -23,8 +23,10 @@ This server provides the following tools:
     *   **Input Parameters**:
         *   `startDate` (string, required): Start date for the report in `YYYY-MM-DD` format.
         *   `endDate` (string, required): End date for the report in `YYYY-MM-DD` format.
+        *   `appName` (string, optional): Limit results to a single configured client. Available clients: `Lyft`, `Self Financial`, `Chime`, `ZipRecruiter`, `Upside`, `Albert`.
         *   `metricIds` (array of strings, optional): Optional array of metric IDs to fetch. Defaults to standard metrics if not provided:
             *   `total_unique_installs_filter`
+            *   `dn_by_total_dvce`
             *   `revenue_total`
             *   `revenue_iap_order_count`
             *   `daily_rat_score`
@@ -38,13 +40,28 @@ This server provides the following tools:
     ```bash
     export SAMSUNG_ISS='your_samsung_issuer'
     export SAMSUNG_PRIVATE_KEY='your_samsung_private_key'
-    export SAMSUNG_CONTENT_ID='your_samsung_content_id'
+    export SAMSUNG_BASE_URL='your_samsung_api_base_url'
     ```
 
     **Required Environment Variables:**
     *   `SAMSUNG_ISS`: Samsung issuer identifier for JWT authentication
     *   `SAMSUNG_PRIVATE_KEY`: Private key for JWT signing (RS256 algorithm)
-    *   `SAMSUNG_CONTENT_ID`: Content ID for which to fetch metrics
+    
+    **Optional Environment Variables:**
+    *   `SAMSUNG_BASE_URL`: Samsung API base URL. If omitted, the server uses its built-in default
+
+## Configured Clients
+
+The package currently ships with a built-in list of supported clients, including:
+
+*   `Lyft`
+*   `Self Financial`
+*   `Chime`
+*   `ZipRecruiter`
+*   `Upside`
+*   `Albert`
+
+To add a new client, update the `SAMSUNG_CONTENT_IDS` constant in `src/index.ts` with the client name and the corresponding Samsung content ID mappings.
 
 ## Usage with Claude Desktop
 
@@ -62,8 +79,7 @@ This server provides the following tools:
           "args": [ "-y", "@feedmob/samsung-reporting" ],
           "env": {
             "SAMSUNG_ISS": "your_samsung_issuer",
-            "SAMSUNG_PRIVATE_KEY": "your_samsung_private_key",
-            "SAMSUNG_CONTENT_ID": "your_samsung_content_id"
+            "SAMSUNG_PRIVATE_KEY": "your_samsung_private_key"
           }
         }
       }
@@ -89,7 +105,7 @@ The JWT token includes:
 1.  Clone the repository.
 2.  Navigate to the `src/samsung-reporting` directory.
 3.  Install dependencies: `npm install`
-4.  Set the required environment variables (`SAMSUNG_ISS`, `SAMSUNG_PRIVATE_KEY`, and `SAMSUNG_CONTENT_ID`).
+4.  Set the required environment variables (`SAMSUNG_ISS` and `SAMSUNG_PRIVATE_KEY`).
 5.  Build the project: `npm run build`
 6.  Run the server directly: `node dist/index.js`
 

--- a/src/samsung-reporting/package-lock.json
+++ b/src/samsung-reporting/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@feedmob/samsung-reporting",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@feedmob/samsung-reporting",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.7.0",
         "dotenv": "^16.4.7",
@@ -144,6 +144,7 @@
       "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -586,6 +587,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -1666,6 +1668,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1767,6 +1770,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.23.tgz",
       "integrity": "sha512-Od2bdMosahjSrSgJtakrwjMDb1zM1A3VIHCPGveZt/3/wlrTWBya2lmEh2OYe4OIu8mPTmmr0gnLHIWQXdtWBg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/samsung-reporting/package.json
+++ b/src/samsung-reporting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feedmob/samsung-reporting",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MCP server for Samsung API",
   "main": "dist/index.js",
   "author": "FeedMob",

--- a/src/samsung-reporting/src/index.ts
+++ b/src/samsung-reporting/src/index.ts
@@ -11,7 +11,7 @@ dotenv.config();
 
 const server = new McpServer({
   name: "Samsung Reporting MCP Server",
-  version: "0.1.4"
+  version: "0.1.5"
 });
 
 // Configuration constants

--- a/src/samsung-reporting/src/index.ts
+++ b/src/samsung-reporting/src/index.ts
@@ -55,6 +55,7 @@ const SAMSUNG_CONTENT_IDS: ContentApp[] = [
   { app: 'Chime', contentIds: ['000008223186'] },
   { app: 'ZipRecruiter', contentIds: ['000008182313'] },
   { app: 'Upside', contentIds: ['000007104981', '000008222297'] },
+  { app: 'Albert', contentIds: ['000008824486'] },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Add Albert as a new configured client with contentId mapping
- Add appName parameter documentation for filtering by specific client
- Add dn_by_total_dvce metric ID to available metrics
- Update README with Configured Clients section
- Replace SAMSUNG_CONTENT_ID with optional SAMSUNG_BASE_URL
- Update Claude Desktop configuration example
- Improve development setup instructions

https://github.com/feed-mob/tracking_admin/issues/22454