### PR TITLE
chore(feedmob-ai-video-hub): bump version to 1.0.2

### DIFF
--- a/src/feedmob-ai-video-hub/package-lock.json
+++ b/src/feedmob-ai-video-hub/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feedmob-ai-video-hub",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feedmob-ai-video-hub",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.0",
         "fastmcp": "^1.21.0",

--- a/src/feedmob-ai-video-hub/package.json
+++ b/src/feedmob-ai-video-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feedmob/ai-video-hub",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "FeedMob AI Video Hub MCP Server",
   "type": "module",
   "main": "dist/index.js",
@@ -36,5 +36,9 @@
     "ai-video",
     "video-management"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/feed-mob/fm-mcp-servers.git"
+  }
 }

--- a/src/feedmob-ai-video-hub/src/index.ts
+++ b/src/feedmob-ai-video-hub/src/index.ts
@@ -134,7 +134,7 @@ async function uploadFile(filePath: string): Promise<UploadResponse> {
 // Create MCP Server
 const server = new FastMCP({
   name: "feedmob-ai-video-hub",
-  version: "1.0.1",
+  version: "1.0.2",
 });
 
 // Tool: list_ai_videos


### PR DESCRIPTION
## Summary
- bump `@feedmob/ai-video-hub` package and MCP server version to `1.0.2`
- add repository metadata required by npm trusted publishing/provenance

## Verification
- `npm run build` in `src/feedmob-ai-video-hub`
- `npm publish --dry-run --access public` in `src/feedmob-ai-video-hub`
- `npm view @feedmob/ai-video-hub version dist-tags --json` confirmed current published latest remains `1.0.1`
- `git diff --check`
