### PR TITLE
refactor: remove status field from ai-video-hub MCP server

### DIFF
--- a/src/feedmob-ai-video-hub/package-lock.json
+++ b/src/feedmob-ai-video-hub/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@feedmob/ai-video-hub",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@feedmob/ai-video-hub",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.0",
         "fastmcp": "^1.21.0",

--- a/src/feedmob-ai-video-hub/package.json
+++ b/src/feedmob-ai-video-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@feedmob/ai-video-hub",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "FeedMob AI Video Hub MCP Server",
   "type": "module",
   "main": "dist/index.js",

--- a/src/feedmob-ai-video-hub/src/index.ts
+++ b/src/feedmob-ai-video-hub/src/index.ts
@@ -35,6 +35,7 @@ interface AiVideo {
   design_rationale_markdown?: string;
   production_notes_markdown?: string;
   reference_count: number;
+  video_url?: string;
   created_at: string;
   updated_at: string;
   references: AiVideoReference[];

--- a/src/feedmob-ai-video-hub/src/index.ts
+++ b/src/feedmob-ai-video-hub/src/index.ts
@@ -27,7 +27,6 @@ interface AiVideo {
   id: number;
   title: string;
   client_name: string;
-  status: string;
   creator: string;
   creator_id: number;
   duration_seconds?: number;
@@ -141,14 +140,10 @@ const server = new FastMCP({
 server.addTool({
   name: "list_ai_videos",
   description:
-    "List AI video entries with optional filters for client, creator, status, and title.",
+    "List AI video entries with optional filters for client, creator, and title.",
   parameters: z.object({
     client_name: z.string().optional().describe("Filter by exact client name"),
     creator_id: z.number().optional().describe("Filter by creator user id"),
-    status: z
-      .enum(["draft", "reviewing", "ready", "archived"])
-      .optional()
-      .describe("Filter by workflow status"),
     title_query: z
       .string()
       .optional()
@@ -164,7 +159,6 @@ server.addTool({
     const params = new URLSearchParams();
     if (args.client_name) params.set("client_name", args.client_name);
     if (args.creator_id) params.set("creator_id", String(args.creator_id));
-    if (args.status) params.set("status", args.status);
     if (args.title_query) params.set("title_query", args.title_query);
     if (args.limit) params.set("limit", String(args.limit));
 
@@ -199,9 +193,6 @@ server.addTool({
   parameters: z.object({
     title: z.string().describe("Video title"),
     client_name: z.string().describe("Client name"),
-    status: z
-      .enum(["draft", "reviewing", "ready", "archived"])
-      .describe("Workflow status"),
     duration_seconds: z.number().optional().describe("Duration in seconds"),
     published_on: z.string().optional().describe("ISO date"),
     source_research_markdown: z
@@ -252,7 +243,6 @@ server.addTool({
         ai_video: {
           title: videoData.title,
           client_name: videoData.client_name,
-          status: videoData.status,
           duration_seconds: videoData.duration_seconds,
           published_on: videoData.published_on,
           source_research_markdown: videoData.source_research_markdown,
@@ -273,10 +263,6 @@ server.addTool({
   description: "Update one or more AI video entries in bulk. Optionally upload a new video file.",
   parameters: z.object({
     ids: z.array(z.number()).describe("AI video ids to update"),
-    status: z
-      .enum(["draft", "reviewing", "ready", "archived"])
-      .optional()
-      .describe("New workflow status"),
     client_name: z.string().optional().describe("New client name"),
     published_on: z.string().optional().describe("ISO date"),
     source_research_markdown: z
@@ -329,7 +315,6 @@ server.addTool({
         body: JSON.stringify({
           ids,
           updates: {
-            status: updates.status,
             client_name: updates.client_name,
             published_on: updates.published_on,
             source_research_markdown: updates.source_research_markdown,

--- a/src/feedmob-ai-video-hub/src/index.ts
+++ b/src/feedmob-ai-video-hub/src/index.ts
@@ -35,7 +35,6 @@ interface AiVideo {
   design_rationale_markdown?: string;
   production_notes_markdown?: string;
   reference_count: number;
-  video_url?: string;
   created_at: string;
   updated_at: string;
   references: AiVideoReference[];

--- a/src/feedmob-ai-video-hub/src/index.ts
+++ b/src/feedmob-ai-video-hub/src/index.ts
@@ -134,7 +134,7 @@ async function uploadFile(filePath: string): Promise<UploadResponse> {
 // Create MCP Server
 const server = new FastMCP({
   name: "feedmob-ai-video-hub",
-  version: "1.0.3",
+  version: "1.0.4",
 });
 
 // Tool: list_ai_videos


### PR DESCRIPTION
## Summary
- Remove status field from AiVideo interface
- Remove status filter from list_ai_videos tool
- Remove status parameter from create_ai_video tool  
- Remove status parameter from update_ai_videos tool
- Update tool descriptions to match API changes

## Related
This PR aligns with the status field removal from the main Rails application.